### PR TITLE
Add RedisReporter for minitest

### DIFF
--- a/ci-queue.gemspec
+++ b/ci-queue.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'redis', '~> 3.3'
   spec.add_development_dependency 'simplecov', '~> 0.12'
+  spec.add_development_dependency 'minitest-reporters', '~> 1.1'
 end

--- a/lib/ci/queue/redis.rb
+++ b/lib/ci/queue/redis.rb
@@ -1,6 +1,7 @@
 require 'redis'
 require 'ci/queue/redis/base'
 require 'ci/queue/redis/worker'
+require 'ci/queue/redis/retry'
 require 'ci/queue/redis/supervisor'
 
 module CI

--- a/lib/ci/queue/redis/base.rb
+++ b/lib/ci/queue/redis/base.rb
@@ -4,7 +4,7 @@ module CI
       class Base
         def initialize(redis:, build_id:)
           @redis = redis
-          @key = "build:#{build_id}"
+          @build_id = build_id
         end
 
         def empty?
@@ -44,10 +44,10 @@ module CI
 
         private
 
-        attr_reader :redis
+        attr_reader :redis, :build_id
 
         def key(*args)
-          [@key, *args].join(':')
+          ['build', build_id, *args].join(':')
         end
 
         def master_status

--- a/lib/ci/queue/redis/retry.rb
+++ b/lib/ci/queue/redis/retry.rb
@@ -1,0 +1,29 @@
+module CI
+  module Queue
+    module Redis
+      class Retry < Static
+        def initialize(tests, redis:, build_id:, worker_id:)
+          @redis = redis
+          @build_id = build_id
+          @worker_id = worker_id
+          super(tests)
+        end
+
+        def minitest_reporters
+          require 'minitest/reporters/redis_reporter'
+          @minitest_reporters ||= [
+            Minitest::Reporters::RedisReporter::Worker.new(
+              redis: redis,
+              build_id: build_id,
+              worker_id: worker_id,
+            )
+          ]
+        end
+
+        private
+
+        attr_reader :redis, :build_id, :worker_id
+      end
+    end
+  end
+end

--- a/lib/ci/queue/redis/worker.rb
+++ b/lib/ci/queue/redis/worker.rb
@@ -35,7 +35,23 @@ module CI
         end
 
         def retry_queue
-          Static.new(redis.lrange(key("worker:#{worker_id}:queue"), 0, -1).reverse)
+          Retry.new(
+            redis.lrange(key("worker:#{worker_id}:queue"), 0, -1).reverse,
+            redis: redis,
+            build_id: build_id,
+            worker_id: worker_id,
+          )
+        end
+
+        def minitest_reporters
+          require 'minitest/reporters/redis_reporter'
+          @minitest_reporters ||= [
+            Minitest::Reporters::RedisReporter::Worker.new(
+              redis: redis,
+              build_id: build_id,
+              worker_id: worker_id,
+            )
+          ]
         end
 
         private

--- a/lib/minitest/queue.rb
+++ b/lib/minitest/queue.rb
@@ -1,8 +1,26 @@
 require 'minitest'
 
+gem 'minitest-reporters', '~> 1.1'
+require 'minitest/reporters'
+
 module Minitest
   module Queue
-    attr_accessor :queue
+    attr_reader :queue
+
+    def queue=(queue)
+      @queue = queue
+      if queue.respond_to?(:minitest_reporters)
+        self.queue_reporters = queue.minitest_reporters
+      else
+        self.queue_reporters = []
+      end
+    end
+
+    def queue_reporters=(reporters)
+      @queue_reporters ||= []
+      Reporters.reporters = ((Reporters.reporters || []) - @queue_reporters) + reporters
+      @queue_reporters = reporters
+    end
 
     SuiteNotFound = Class.new(StandardError)
 

--- a/lib/minitest/reporters/failure_formatter.rb
+++ b/lib/minitest/reporters/failure_formatter.rb
@@ -1,0 +1,64 @@
+require 'delegate'
+
+module Minitest
+  module Reporters
+    class FailureFormatter < SimpleDelegator
+      include ANSI::Code
+
+      def initialize(test)
+        @test = test
+        super
+      end
+
+      def to_s
+        [
+          header,
+          body,
+          "\n"
+        ].flatten.compact.join("\n")
+      end
+
+      def to_h
+        {
+          test_and_module_name: "#{test.class}##{test.name}",
+          test_name: test.name,
+          output: to_s,
+        }
+      end
+
+      private
+
+      attr_reader :test
+
+      def header
+        "#{red(status)} #{test.class}##{test.name}"
+      end
+
+      def status
+        if test.error?
+          'ERROR'
+        elsif test.failure
+          'FAIL'
+        else
+          raise ArgumentError, "Couldn't infer test status"
+        end
+      end
+
+      def body
+        error = test.failure
+        message = if error.is_a?(MiniTest::UnexpectedError)
+          "#{error.exception.class}: #{error.exception.message}"
+        else
+          error.exception.message
+        end
+
+        backtrace = Minitest.filter_backtrace(error.backtrace).map { |line| '    ' + relativize(line) }
+        [yellow(message), *backtrace].join("\n")
+      end
+
+      def relativize(trace_line)
+        trace_line.sub(/\A#{Regexp.escape("#{Dir.pwd}/")}/, '')
+      end
+    end
+  end
+end

--- a/lib/minitest/reporters/redis_reporter.rb
+++ b/lib/minitest/reporters/redis_reporter.rb
@@ -1,0 +1,191 @@
+require 'minitest/reporters/failure_formatter'
+
+module Minitest
+  module Reporters
+    module RedisReporter
+      include ANSI::Code
+
+      COUNTERS = %w(
+        assertions
+        errors
+        failures
+        skips
+        total_time
+      ).freeze
+
+      class << self
+        attr_accessor :failure_formatter
+      end
+      self.failure_formatter = FailureFormatter
+
+      class Error
+        class << self
+          def load(payload)
+            Marshal.load(payload)
+          end
+        end
+
+        def initialize(data)
+          @data = data
+        end
+
+        def dump
+          Marshal.dump(self)
+        end
+
+        def test_name
+          @data[:test_name]
+        end
+
+        def test_and_module_name
+          @data[:test_and_module_name]
+        end
+
+        def to_s
+          output
+        end
+
+        def output
+          @data[:output]
+        end
+      end
+
+      class Base < BaseReporter
+        def initialize(redis:, build_id:, **options)
+          @redis = redis
+          @key = "build:#{build_id}"
+          super(options)
+        end
+
+        def total
+          redis.get(key('total')).to_i
+        end
+
+        def processed
+          redis.get(key('processed')).to_i
+        end
+
+        def completed?
+          total > 0 && total == processed
+        end
+
+        def error_reports
+          redis.hgetall(key('error-reports')).sort_by(&:first).map { |k, v| Error.load(v) }
+        end
+
+        private
+
+        attr_reader :redis
+
+        def key(*args)
+          [@key, *args].join(':')
+        end
+      end
+
+      class Summary < Base
+        include ANSI::Code
+
+        def report(io: STDOUT)
+          io.puts aggregates
+          errors = error_reports
+          io.puts errors
+
+          errors.empty?
+        end
+
+        def record(*)
+          raise NotImplementedError
+        end
+
+        def failures
+          fetch_summary['failures'].to_i
+        end
+
+        def errors
+          fetch_summary['errors'].to_i
+        end
+
+        def assertions
+          fetch_summary['assertions'].to_i
+        end
+
+        def skips
+          fetch_summary['skips'].to_i
+        end
+
+        def total_time
+          fetch_summary['total_time'].to_f
+        end
+
+        private
+
+        def aggregates
+          success = failures.zero? && errors.zero?
+          failures_count = "#{failures} failures, #{errors} errors,"
+
+          [
+            'Ran %d tests, %d assertions,' % [processed, assertions],
+            success ? green(failures_count) : red(failures_count),
+            yellow("#{skips} skips"),
+            'in %.2fs (aggregated).' % total_time,
+          ].join(' ')
+        end
+
+        def fetch_summary
+          @summary ||= begin
+            counts = redis.pipelined do
+              COUNTERS.each { |c| redis.hgetall(key(c)) }
+            end
+            COUNTERS.zip(counts.map { |h| h.values.map(&:to_f).inject(:+).to_f }).to_h
+          end
+        end
+      end
+
+      class Worker < Base
+        def initialize(worker_id:, **options)
+          super
+          @worker_id = worker_id
+          self.failures = 0
+          self.errors = 0
+          self.skips = 0
+        end
+
+        def report
+          # noop
+        end
+
+        def record(test)
+          super
+
+          self.total_time = Minitest.clock_time - start_time
+          if test.skipped?
+            self.skips += 1
+          elsif test.error?
+            self.errors += 1
+          elsif test.failure
+            self.failures += 1
+          end
+
+          redis.multi do
+            if (test.failure || test.error?) && !test.skipped?
+              redis.hset(key('error-reports'), "#{test.class}##{test.name}", dump(test))
+            else
+              redis.hdel(key('error-reports'), "#{test.class}##{test.name}")
+            end
+            COUNTERS.each do |counter|
+              redis.hset(key(counter), worker_id, send(counter))
+            end
+          end
+        end
+
+        private
+
+        def dump(test)
+          Error.new(RedisReporter.failure_formatter.new(test).to_h).dump
+        end
+
+        attr_reader :worker_id, :aggregates
+      end
+    end
+  end
+end

--- a/test/fixtures/dummy_test.rb
+++ b/test/fixtures/dummy_test.rb
@@ -2,16 +2,20 @@ require 'test_helper'
 
 class ATest < Minitest::Test
   def test_foo
+    skip
   end
 
   def test_bar
+    assert false
   end
 end
 
 class BTest < Minitest::Test
   def test_foo
+    assert true
   end
 
   def test_bar
+    1 + '1'
   end
 end

--- a/test/fixtures/test_helper.rb
+++ b/test/fixtures/test_helper.rb
@@ -1,3 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
 
+require 'minitest/reporters'
+Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new])
 require 'minitest/autorun'

--- a/test/integration/redis_test.rb
+++ b/test/integration/redis_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Integration
   class RedisTest < Minitest::Test
+    include OutputHelpers
+
     def setup
       @redis = Redis.new(db: 7)
       @redis.flushdb
@@ -9,9 +11,36 @@ module Integration
 
     def test_redis_runner
       output = `ruby -Itest/fixtures test/fixtures/redis-runner.rb`.lines.map(&:strip).last
-      assert_equal '4 runs, 0 assertions, 0 failures, 0 errors, 0 skips', output
+      assert_equal '4 tests, 2 assertions, 1 failures, 1 errors, 1 skips', output
       output = `ruby -Itest/fixtures test/fixtures/redis-runner.rb retry`.lines.map(&:strip).last
-      assert_equal '4 runs, 0 assertions, 0 failures, 0 errors, 0 skips', output
+      assert_equal '4 tests, 2 assertions, 1 failures, 1 errors, 1 skips', output
+    end
+
+    def test_redis_reporter
+      summary = Minitest::Reporters::RedisReporter::Summary.new(
+        redis: @redis,
+        build_id: 1,
+      )
+
+      output = `ruby -Itest/fixtures test/fixtures/redis-runner.rb`.lines.map(&:strip).last
+      assert_equal '4 tests, 2 assertions, 1 failures, 1 errors, 1 skips', output
+
+      io = StringIO.new
+      summary.report(io: io)
+      report = strip_heredoc <<-END
+        Ran 4 tests, 2 assertions, 1 failures, 1 errors, 1 skips in 0.00s (aggregated).
+        FAIL ATest#test_bar
+        Expected false to be truthy.
+            test/fixtures/dummy_test.rb:9:in `test_bar'
+            lib/ci/queue/redis/worker.rb:32:in `poll'
+
+        ERROR BTest#test_bar
+        TypeError: String can't be coerced into Fixnum
+            test/fixtures/dummy_test.rb:19:in `+'
+            test/fixtures/dummy_test.rb:19:in `test_bar'
+
+      END
+      assert_equal report, decolorize_output(io.tap(&:rewind).read)
     end
   end
 end

--- a/test/minittest/reporters/redis_reporter_test.rb
+++ b/test/minittest/reporters/redis_reporter_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+module Minitest::Reporters
+  class RedisReporterTest < Minitest::Test
+    def setup
+      @redis = ::Redis.new(db: 7)
+      @redis.flushdb
+      @queue = worker(1)
+      @reporter = @queue.minitest_reporters.first
+      @reporter.start
+    end
+
+    def test_aggregation
+      @reporter.record(runnable('a', Minitest::Assertion.new))
+      @reporter.record(runnable('b', Minitest::UnexpectedError.new(StandardError.new)))
+
+      second_queue = worker(2)
+      second_reporter = second_queue.minitest_reporters.first
+      second_reporter.start
+
+      second_reporter.record(runnable('c', Minitest::Assertion.new))
+      second_reporter.record(runnable('d', Minitest::UnexpectedError.new(StandardError.new)))
+      second_reporter.record(runnable('e', Minitest::Skip.new))
+      second_reporter.record(runnable('f', Minitest::UnexpectedError.new(StandardError.new)))
+
+      assert_equal 6, summary.assertions
+      assert_equal 2, summary.failures
+      assert_equal 3, summary.errors
+      assert_equal 1, summary.skips
+      assert_equal 5, summary.error_reports.size
+    end
+
+    def test_retrying_test
+      @reporter.record(runnable('a', Minitest::Assertion.new))
+      assert_equal 1, summary.error_reports.size
+
+      second_queue = worker(2)
+      second_reporter = second_queue.minitest_reporters.first
+      second_reporter.start
+
+      second_reporter.record(runnable('a'))
+      assert_equal 0, summary.error_reports.size
+    end
+
+    private
+
+    def runnable(name, failure = nil)
+      runnable = Minitest::Test.new(name)
+      runnable.failures << failure if failure
+      runnable.assertions += 1
+      runnable
+    end
+
+    def worker(id)
+      CI::Queue::Redis.new(
+        ['Foo'],
+        redis: @redis,
+        build_id: '42',
+        worker_id: id.to_s,
+        timeout: 0.2,
+      )
+    end
+
+    def summary
+      @summary ||= Minitest::Reporters::RedisReporter::Summary.new(
+        redis: @redis,
+        build_id: '42',
+      )
+    end
+  end
+end

--- a/test/support/output_helpers.rb
+++ b/test/support/output_helpers.rb
@@ -1,0 +1,12 @@
+module OutputHelpers
+  private
+
+  def decolorize_output(output)
+    output.gsub(/\e\[\d+m/, '')
+  end
+
+  def strip_heredoc(heredoc)
+    indent = heredoc.scan(/^[ \t]*(?=\S)/).min.size || 0
+    heredoc.gsub(/^[ \t]{#{indent}}/, '')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,9 +5,13 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'ci/queue'
 require 'ci/queue/redis'
+require 'minitest/queue'
+require 'minitest/reporters/redis_reporter'
 require 'minitest/autorun'
 
 require 'thread'
+require 'stringio'
+
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].sort.each do |file|
   require file
 end


### PR DESCRIPTION
Add a RedisReporter for minitest, to be able to centralize the result for the CI run.

@Shopify/pipeline for review please (Note: It's at 99% what was inside Shopify, with added test coverage.)