### PR TITLE
Requeue tests with an offset

### DIFF
--- a/test/support/queue_helpers.rb
+++ b/test/support/queue_helpers.rb
@@ -6,7 +6,7 @@ module QueueHelper
     queue.poll do |test|
       yield test if block_given?
       test_order << test
-      queue.acknowledge(test, success)
+      queue.acknowledge(test, success.respond_to?(:call) ? success.call(test) : success)
     end
     test_order
   end


### PR DESCRIPTION
### Why?

Since the worker is ready to pop a test right after it requeued a failing one, almost everytime it's the same worker that re-runs it.

It's not terrible, but it would be better if the test was re-ran by another worker, because if the test was failing due to some leaked state, another worker have more chances to make it pass.

Alternatively we could `lpush` the test back, but I'm not a fan since it mean all the requeued tests would be re-ran at the end of the build, so if you configured the queue to requeue tests more than once, it would have detrimental effect on performance.

Also you might wonder: why a static offset? 

Initially I wanted to randomize it based on the number of workers, but then realized we don't have that information ATM, and it seemed like another information to pass to the constructor for very little gain.

@Shopify/pipeline for review please.

