### PR TITLE
Fix for missing variable

### DIFF
--- a/lib/minitest/queue.rb
+++ b/lib/minitest/queue.rb
@@ -93,7 +93,7 @@ module Minitest
           end
           reporter.record(result)
         else
-          raise SuiteNotFound, "Couldn't find suite matching: #{msg.inspect}"
+          raise SuiteNotFound, "Couldn't find suite matching: #{class_name}"
         end
       end
     end

--- a/lib/minitest/queue.rb
+++ b/lib/minitest/queue.rb
@@ -93,7 +93,7 @@ module Minitest
           end
           reporter.record(result)
         else
-          raise SuiteNotFound, "Couldn't find suite matching: #{class_name}"
+          raise SuiteNotFound, "Couldn't find suite matching: #{test_name}"
         end
       end
     end


### PR DESCRIPTION
`msg` doesn't exist here. Was throwing errors for me locally.

@byroot 