### PR TITLE
Implement Minitest::Reporters::OrderReporter

### DIFF
--- a/lib/minitest/reporters/order_reporter.rb
+++ b/lib/minitest/reporters/order_reporter.rb
@@ -1,0 +1,21 @@
+require 'minitest/reporters'
+
+class Minitest::Reporters::OrderReporter < Minitest::Reporters::BaseReporter
+  def initialize(options = {})
+    @path = options.delete(:path)
+    super
+  end
+
+  def start
+    @file = File.open(@path, 'w+')
+    super
+  end
+
+  def record(test)
+    @file.puts("#{test.class}##{test.name}")
+  end
+
+  def report
+    @file.close
+  end
+end

--- a/test/minitest/reporters/order_reporter_test.rb
+++ b/test/minitest/reporters/order_reporter_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+module Minitest::Reporters
+  class OrderReporterTest < Minitest::Test
+    include ReporterTestHelper
+
+    def setup
+      @reporter = OrderReporter.new(path: log_path)
+      @reporter.start
+    end
+
+    def test_record
+      @reporter.record(runnable('a'))
+      @reporter.record(runnable('b'))
+      @reporter.report
+      assert_equal ['Minitest::Test#a', 'Minitest::Test#b'], File.readlines(log_path).map(&:chomp)
+    end
+
+    private
+
+    def delete_log
+      File.delete(log_path) if File.exists?(log_path)
+    end
+
+    def log_path
+      @path ||= File.join(Dir.tmpdir, 'test_order.log')
+    end
+  end
+end

--- a/test/minitest/reporters/redis_reporter_test.rb
+++ b/test/minitest/reporters/redis_reporter_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Minitest::Reporters
   class RedisReporterTest < Minitest::Test
+    include ReporterTestHelper
+
     def setup
       @redis = ::Redis.new(db: 7)
       @redis.flushdb
@@ -43,13 +45,6 @@ module Minitest::Reporters
     end
 
     private
-
-    def runnable(name, failure = nil)
-      runnable = Minitest::Test.new(name)
-      runnable.failures << failure if failure
-      runnable.assertions += 1
-      runnable
-    end
 
     def worker(id)
       CI::Queue::Redis.new(

--- a/test/support/reporter_test_helper.rb
+++ b/test/support/reporter_test_helper.rb
@@ -1,0 +1,10 @@
+module ReporterTestHelper
+  private
+
+  def runnable(name, failure = nil)
+    runnable = Minitest::Test.new(name)
+    runnable.failures << failure if failure
+    runnable.assertions += 1
+    runnable
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,11 +7,13 @@ require 'ci/queue'
 require 'ci/queue/redis'
 require 'minitest/queue'
 require 'minitest/reporters/redis_reporter'
+require 'minitest/reporters/order_reporter'
 require 'minitest/autorun'
 
 
 Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
 
+require 'tmpdir'
 require 'thread'
 require 'stringio'
 


### PR DESCRIPTION
This reporter logs the test in a file in the order they were executed. The log can then be used to populate `CI::Queue::File` to replay the tests in the same order.

@Shopify/pipeline for review.