### PR TITLE
Handle redis being down / unreachable

### DIFF
--- a/ci-queue.gemspec
+++ b/ci-queue.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', "~> 10.0"
-  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest', '~> 5.9.1'
   spec.add_development_dependency 'redis', '~> 3.3'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'minitest-reporters', '~> 1.1'

--- a/lib/ci/queue/redis/worker.rb
+++ b/lib/ci/queue/redis/worker.rb
@@ -45,6 +45,7 @@ module CI
               sleep 0.05
             end
           end
+        rescue ::Redis::BaseConnectionError
         end
 
         def retry_queue(**args)
@@ -193,6 +194,8 @@ module CI
               redis.set(key('master-status'), 'ready')
             end
           end
+        rescue ::Redis::BaseConnectionError
+          raise if @master
         end
       end
     end

--- a/test/fixtures/redis-runner.rb
+++ b/test/fixtures/redis-runner.rb
@@ -10,7 +10,7 @@ Minitest::Reporters.use!([Minitest::Reporters::QueueReporter.new])
 
 Minitest.queue = CI::Queue::Redis.new(
   Minitest.loaded_tests,
-  redis: ::Redis.new(db: 7),
+  redis: ::Redis.new(host: ENV.fetch('REDIS_HOST', nil), db: 7, timeout: 1),
   build_id: 1,
   worker_id: 1,
   timeout: 1,

--- a/test/integration/redis_test.rb
+++ b/test/integration/redis_test.rb
@@ -10,10 +10,19 @@ module Integration
     end
 
     def test_redis_runner
-      output = normalize(`ruby -Itest/fixtures test/fixtures/redis-runner.rb`.lines.map(&:strip).last)
+      output = normalize(`ruby -Itest/fixtures test/fixtures/redis-runner.rb`.lines.last.strip)
       assert_equal 'Ran 8 tests, 5 assertions, 1 failures, 1 errors, 1 skips, 3 requeues in X.XXs', output
       output = normalize(`ruby -Itest/fixtures test/fixtures/redis-runner.rb retry`.lines.map(&:strip).last)
       assert_equal 'Ran 8 tests, 5 assertions, 1 failures, 1 errors, 1 skips, 3 requeues in X.XXs', output
+    end
+
+    def test_down_redis
+      previous_redis_host = ENV['REDIS_HOST']
+      ENV['REDIS_HOST'] = 'example.com'
+      output = normalize(`ruby -Itest/fixtures test/fixtures/redis-runner.rb`.lines.last.strip)
+      assert_equal 'Ran 0 tests, 0 assertions, 0 failures, 0 errors, 0 skips, 0 requeues in X.XXs', output
+    ensure
+      ENV['REDIS_HOST'] = previous_redis_host
     end
 
     def test_redis_reporter
@@ -22,7 +31,7 @@ module Integration
         build_id: 1,
       )
 
-      output = normalize(`ruby -Itest/fixtures test/fixtures/redis-runner.rb`.lines.map(&:strip).last)
+      output = normalize(`ruby -Itest/fixtures test/fixtures/redis-runner.rb`.lines.last.strip)
       assert_equal 'Ran 8 tests, 5 assertions, 1 failures, 1 errors, 1 skips, 3 requeues in X.XXs', output
 
       io = StringIO.new


### PR DESCRIPTION
If Redis is unreacheable, we assume that either:

  - It's just for that single worker, in this case other workers will pick up the slack.
  - It's actually down for everyone, the summary step will detect it.

@Shopify/pipeline for review please.