### PR TITLE
Register workers on boot, surface on `Redis::Base`

### DIFF
--- a/lib/ci/queue/redis/base.rb
+++ b/lib/ci/queue/redis/base.rb
@@ -42,6 +42,10 @@ module CI
           raise LostMaster, "The master worker is still `#{master_status}` after 10 seconds waiting."
         end
 
+        def workers_count
+          redis.scard(key('workers'))
+        end
+
         private
 
         attr_reader :redis, :build_id

--- a/lib/ci/queue/redis/worker.rb
+++ b/lib/ci/queue/redis/worker.rb
@@ -194,8 +194,13 @@ module CI
               redis.set(key('master-status'), 'ready')
             end
           end
+          register
         rescue ::Redis::BaseConnectionError
           raise if @master
+        end
+
+        def register
+          redis.sadd(key('workers'), worker_id)
         end
       end
     end

--- a/test/ci/queue/redis_supervisor_test.rb
+++ b/test/ci/queue/redis_supervisor_test.rb
@@ -37,6 +37,12 @@ class CI::Queue::Redis::SupervisorTest < Minitest::Test
     assert_equal true, workers_done
   end
 
+  def test_num_workers
+    assert_equal 0, @supervisor.workers_count
+    worker(1)
+    assert_equal 1, @supervisor.workers_count
+  end
+
   private
 
   def worker(id)

--- a/test/ci/queue/redis_test.rb
+++ b/test/ci/queue/redis_test.rb
@@ -78,6 +78,12 @@ class CI::Queue::RedisTest < Minitest::Test
     assert_equal TEST_LIST.sort, second_queue.retry_queue.to_a.sort
   end
 
+  def test_workers_register
+    assert_equal 1, @redis.scard(('build:42:workers'))
+    worker(2)
+    assert_equal 2, @redis.scard(('build:42:workers'))
+  end
+
   private
 
   def worker(id, **args)


### PR DESCRIPTION
@Shopify/pipeline for review. I wasn't 100% sure when is best to call `register`, but doing so after the tests are pushed means at least the environment is sane.