### PR TITLE
Write the test to the test order log file before it’s run, rather than after

### DIFF
--- a/lib/minitest/reporters/order_reporter.rb
+++ b/lib/minitest/reporters/order_reporter.rb
@@ -11,7 +11,8 @@ class Minitest::Reporters::OrderReporter < Minitest::Reporters::BaseReporter
     super
   end
 
-  def record(test)
+  def before_test(test)
+    super
     @file.puts("#{test.class}##{test.name}")
   end
 

--- a/test/minitest/reporters/order_reporter_test.rb
+++ b/test/minitest/reporters/order_reporter_test.rb
@@ -9,9 +9,9 @@ module Minitest::Reporters
       @reporter.start
     end
 
-    def test_record
-      @reporter.record(runnable('a'))
-      @reporter.record(runnable('b'))
+    def test_before_test
+      @reporter.before_test(runnable('a'))
+      @reporter.before_test(runnable('b'))
       @reporter.report
       assert_equal ['Minitest::Test#a', 'Minitest::Test#b'], File.readlines(log_path).map(&:chomp)
     end


### PR DESCRIPTION
This allows us to spot which tests was running in case of problems, like timeouts or segfaults.

