### PR TITLE
fix exiting of testloop before all tests have returned

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -22,7 +22,7 @@ lint:
 autolint: autopep8 lint
 
 run_tests: clean
-	py.test --durations=10 tests
+	py.test --durations=10 -vv tests
 
 test: autopep8 run_tests lint
 

--- a/python/ciqueue/distributed.py
+++ b/python/ciqueue/distributed.py
@@ -74,7 +74,6 @@ class Worker(Base):
                 yield test
             else:
                 time.sleep(0.05)
-                return
 
     def shutdown(self):
         self.shutdown_required = True

--- a/python/tests/shared.py
+++ b/python/tests/shared.py
@@ -36,8 +36,9 @@ class QueueImplementation(object):
 
         test_order = []
         for test in queue:
-            test_order.append(test)
             queue.requeue(test)
+            queue.acknowledge(test)
+            test_order.append(test)
         return test_order
 
     def test_requeue(self):


### PR DESCRIPTION
This fixes the issue we were seeing in starscream where an infrastructure error would occur mid-test, and we'd wait indefinitely for the `test summary` to complete. The problem was that we were exiting the test worker loop before all the tests were completed.

Thanks @casperisfine for explaining how it _should_ work. That really helped me debug this.
