### PR TITLE
Allow to customize error encoder

### DIFF
--- a/ruby/lib/minitest/reporters/redis_reporter.rb
+++ b/ruby/lib/minitest/reporters/redis_reporter.rb
@@ -22,17 +22,21 @@ module Minitest
 
       class Error
         class << self
+          attr_accessor :coder
+
           def load(payload)
-            Marshal.load(payload)
+            new(coder.load(payload))
           end
         end
+
+        self.coder = Marshal
 
         def initialize(data)
           @data = data
         end
 
         def dump
-          Marshal.dump(self)
+          self.class.coder.dump(@data)
         end
 
         def test_name


### PR DESCRIPTION
Since they include the backtrace etc, error reports can be quite big. If for some reason all the test of a build fail (some low level error), it can generate huge amount of error report in redis, and trigger lots of evictions.

This PR allow the host project to customize how the error reports are encoded, allowing to use more efficient encoders then straight Marshal, e.g Marshal + gzip, or messagepack + snappy, etc

cc @solackerman could be worth adding a similar capacity to the pytest version.