### PR TITLE
small fixes

### DIFF
--- a/python/ciqueue/_pytest/test_queue.py
+++ b/python/ciqueue/_pytest/test_queue.py
@@ -11,8 +11,7 @@ class InvalidRedisUrl(Exception):
 
 
 def key_item(item):
-    # TODO: discuss better identifier # pylint: disable=fixme
-    return item.location[0] + '@' + item.location[2]
+    return item.nodeid
 
 
 def parse_worker_args(query_string, tests_index):

--- a/python/ciqueue/pytest_report.py
+++ b/python/ciqueue/pytest_report.py
@@ -6,6 +6,7 @@ py.test -p ciqueue.pytest_report --queue redis://<host>:6379?build=<build_id>&re
 
 from __future__ import absolute_import
 from __future__ import print_function
+import zlib
 import dill
 import pytest
 from _pytest import runner
@@ -43,7 +44,7 @@ def pytest_collection_modifyitems(session, config, items):  # pylint: disable=un
         # store the errors on setup/test/teardown to item.error_reports
         key = test_queue.key_item(item)
         if key in error_reports:
-            item.error_reports = dill.loads(error_reports[key])
+            item.error_reports = dill.loads(zlib.decompress(error_reports[key]))
             for _, call_dict in item.error_reports.items():
                 call_dict['excinfo'] = outcomes.swap_back_original(call_dict['excinfo'])
 

--- a/python/tests/test_pytest.py
+++ b/python/tests/test_pytest.py
@@ -49,7 +49,7 @@ class TestIntegration(object):
         output = check_output(self.no_check_cmd.format(queue, filename))
         assert '= 4 failed, 2 passed, 4 skipped, 1 xpassed, 6 error in' in output, output
         assert 'integrations/pytest/test_all.py:27: skipping test message' in output, output
-        assert ' RETRYING ' in output, output
+        assert ' WILL_RETRY ' in output, output
 
         expected_messages(check_output(self.no_check_report_cmd.format(queue, filename)))
 


### PR DESCRIPTION
This PR fixes a bunch of little things with the python implementation:
 - it adds compression/decompression for the errors being pushed to redis. This is already a feature in the ruby implementation.
 - `key_item(item)` now returns pytest's builtin test identifier, instead of the something made up.
 - when reporting that a test will be retried, we will now output the message `WILL_RETRY` instead of `RETRYING`.
 - when an error occurs while collecting the tests, we no longer push the tests to ci anyways. This fixes https://github.com/Shopify/ci-queue/issues/30 where the summary agent waits indefinitely for the tests to complete.