### PR TITLE
catch pickles exception

### DIFF
--- a/python/ciqueue/_pytest/outcomes.py
+++ b/python/ciqueue/_pytest/outcomes.py
@@ -40,11 +40,17 @@ DESERIALIZE_TYPES = {Skipped: runner.Skipped,
 
 
 def swap_in_serializable(excinfo):
+    def pickles(excinfo):
+        try:
+            return dill.pickles(excinfo)
+        except:  # pylint: disable=bare-except
+            return False
+
     if excinfo.type in SERIALIZE_TYPES:
         cls = SERIALIZE_TYPES[excinfo.type]
         tup = (cls, cls(*excinfo.value.args), excinfo.tb)
         excinfo = code.ExceptionInfo(tup)
-    elif not dill.pickles(excinfo):
+    elif not pickles(excinfo):
         tup = (UnserializableException,
                UnserializableException(
                    "Actual Exception thrown on test node was %r" %


### PR DESCRIPTION
This PR fixes the following error:
https://buildkite.com/shopify/starscream-production-ci/builds/2118#528b0851-8c5c-4652-b728-31a2d52e8c23
It's possible for dill.pickles(...) to raise an Exception while trying to determine if an object is picklable or not. In all such cases, it's not picklable and should return False. 