### PR TITLE
Decouple queue instantiation and population

### DIFF
--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -1,3 +1,4 @@
 require 'ci/queue/version'
+require 'ci/queue/index'
 require 'ci/queue/static'
 require 'ci/queue/file'

--- a/ruby/lib/ci/queue/index.rb
+++ b/ruby/lib/ci/queue/index.rb
@@ -1,0 +1,20 @@
+module CI
+  module Queue
+    class Index
+      def initialize(objects, &indexer)
+        @index = objects.map { |o| [indexer.call(o), o] }.to_h
+        @indexer = indexer
+      end
+
+      def fetch(key)
+        @index.fetch(key)
+      end
+
+      def key(value)
+        key = @indexer.call(value)
+        raise KeyError, "value not found: #{value.inspect}" unless @index.key?(key)
+        key
+      end
+    end
+  end
+end

--- a/ruby/lib/ci/queue/redis/supervisor.rb
+++ b/ruby/lib/ci/queue/redis/supervisor.rb
@@ -9,7 +9,7 @@ module CI
         def wait_for_workers
           return false unless wait_for_master
 
-          sleep 0.1 until empty?
+          sleep 0.1 until exhausted?
           true
         end
       end

--- a/ruby/test/ci/queue/file_test.rb
+++ b/ruby/test/ci/queue/file_test.rb
@@ -5,8 +5,10 @@ class CI::Queue::FileTest < Minitest::Test
 
   TEST_LIST_PATH = '/tmp/queue-test.txt'.freeze
 
-  def setup
-    File.write(TEST_LIST_PATH, TEST_LIST.join("\n"))
-    @queue = CI::Queue::File.new(TEST_LIST_PATH, max_requeues: 1, requeue_tolerance: 0.1)
+  private
+
+  def build_queue
+    File.write(TEST_LIST_PATH, TEST_LIST.map(&:name).join("\n"))
+    CI::Queue::File.new(TEST_LIST_PATH, max_requeues: 1, requeue_tolerance: 0.1)
   end
 end

--- a/ruby/test/ci/queue/redis_supervisor_test.rb
+++ b/ruby/test/ci/queue/redis_supervisor_test.rb
@@ -47,12 +47,11 @@ class CI::Queue::Redis::SupervisorTest < Minitest::Test
 
   def worker(id)
     CI::Queue::Redis.new(
-      SharedQueueAssertions::TEST_LIST,
       redis: @redis,
       build_id: '42',
       worker_id: id.to_s,
       timeout: 0.2,
-    )
+    ).populate(SharedQueueAssertions::TEST_LIST, &:name)
   end
 
   def supervisor

--- a/ruby/test/ci/queue/static_test.rb
+++ b/ruby/test/ci/queue/static_test.rb
@@ -3,7 +3,9 @@ require 'test_helper'
 class CI::Queue::StaticTest < Minitest::Test
   include SharedQueueAssertions
 
-  def setup
-    @queue = CI::Queue::Static.new(TEST_LIST.dup, max_requeues: 1, requeue_tolerance: 0.1)
+  private
+
+  def build_queue
+    CI::Queue::Static.new(TEST_LIST.map(&:name), max_requeues: 1, requeue_tolerance: 0.1)
   end
 end

--- a/ruby/test/fixtures/redis-runner.rb
+++ b/ruby/test/fixtures/redis-runner.rb
@@ -10,7 +10,6 @@ require 'ci/queue/redis'
 Minitest::Reporters.use!([Minitest::Reporters::QueueReporter.new])
 
 Minitest.queue = CI::Queue::Redis.new(
-  Minitest.loaded_tests,
   redis: ::Redis.new(host: ENV.fetch('REDIS_HOST', nil), db: 7, timeout: 1),
   build_id: 1,
   worker_id: 1,
@@ -25,3 +24,5 @@ if ARGV.first == 'retry'
     requeue_tolerance: 1.0,
   )
 end
+
+Minitest.queue.populate(Minitest.loaded_tests, &:to_s)

--- a/ruby/test/minitest/reporters/redis_reporter_test.rb
+++ b/ruby/test/minitest/reporters/redis_reporter_test.rb
@@ -48,12 +48,11 @@ module Minitest::Reporters
 
     def worker(id)
       CI::Queue::Redis.new(
-        ['Foo'],
         redis: @redis,
         build_id: '42',
         worker_id: id.to_s,
         timeout: 0.2,
-      )
+      ).populate(%w(a b c d e f g).map { |n| runnable(n) }, &:name)
     end
 
     def summary


### PR DESCRIPTION
Fix: https://github.com/Shopify/ci-queue/issues/19

This allows to check if the queue was exhausted without having to boot the entire test environment, which should allow a late worker to exit faster.

This PR also change the queue interface. Queues now receive and return arbitrary objects instead of strings. This will make it easier to implement adapters for test frameworks others than Minitest.