### PR TITLE
Allow to customize output based on the CI provider

### DIFF
--- a/ruby/lib/minitest/reporters/output_helpers.rb
+++ b/ruby/lib/minitest/reporters/output_helpers.rb
@@ -1,0 +1,61 @@
+module Minitest
+  module Reporters
+    module OutputHelpers
+      private
+
+      def step(*args)
+        ci_provider.step(*args)
+      end
+
+      def reopen_previous_step
+        ci_provider.reopen_previous_step
+      end
+
+      def close_previous_step
+        ci_provider.close_previous_step
+      end
+
+      def ci_provider
+        @ci_provider ||= if ENV['BUILDKITE']
+          BuildkiteOutput
+        else
+          DefaultOutput
+        end
+      end
+
+
+      module DefaultOutput
+        extend self
+
+        def step(title, collapsed: true)
+          puts title
+        end
+
+        def reopen_previous_step
+          # noop
+        end
+
+        def close_previous_step
+          # noop
+        end
+      end
+
+      module BuildkiteOutput
+        extend self
+
+        def step(title, collapsed: true)
+          prefix = collapsed ? '---' : '+++'
+          puts "#{prefix} #{title}"
+        end
+
+        def reopen_previous_step
+          puts '^^^ +++'
+        end
+
+        def close_previous_step
+          puts '^^^ ---'
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/minitest/reporters/queue_reporter.rb
+++ b/ruby/lib/minitest/reporters/queue_reporter.rb
@@ -1,9 +1,11 @@
 require 'minitest/reporters'
+require 'minitest/reporters/output_helpers'
 
 module Minitest
   module Reporters
     class QueueReporter < BaseReporter
       include ANSI::Code
+      include OutputHelpers
       attr_accessor :requeues
 
       def initialize(*)
@@ -20,9 +22,10 @@ module Minitest
       private
 
       def print_report
+        reopen_previous_step if failures > 0 || errors > 0
         success = failures.zero? && errors.zero?
         failures_count = "#{failures} failures, #{errors} errors,"
-        puts [
+        step [
           'Ran %d tests, %d assertions,' % [count, assertions],
           success ? green(failures_count) : red(failures_count),
           yellow("#{skips} skips, #{requeues} requeues"),

--- a/ruby/test/integration/redis_test.rb
+++ b/ruby/test/integration/redis_test.rb
@@ -10,50 +10,84 @@ module Integration
       @redis.flushdb
     end
 
+    def test_buildkite_output
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          'exe/minitest-queue',
+          '--url', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest/fixtures',
+          'test/fixtures/dummy_test.rb',
+        )
+      end
+
+      assert_empty err
+      output = normalize(out.lines.last.strip)
+      assert_equal '--- Ran 8 tests, 5 assertions, 1 failures, 1 errors, 1 skips, 3 requeues in X.XXs', output
+    end
+
     def test_redis_runner
-      output = normalize(`
-        exe/minitest-queue \
-        --url '#{@redis_url}' \
-        --seed foobar \
-        --build 1 \
-        --worker 1 \
-        --timeout 1 \
-        --max-requeues 1  \
-        --requeue-tolerance 1  \
-        -Itest/fixtures \
-        test/fixtures/dummy_test.rb \
-      `.lines.last.strip)
+      out, err = capture_subprocess_io do
+        system(
+          'exe/minitest-queue',
+          '--url', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest/fixtures',
+          'test/fixtures/dummy_test.rb',
+        )
+      end
+      assert_empty err
+      output = normalize(out.lines.last.strip)
       assert_equal 'Ran 8 tests, 5 assertions, 1 failures, 1 errors, 1 skips, 3 requeues in X.XXs', output
 
-      output = normalize(`
-        exe/minitest-queue \
-        --retry \\
-        --url '#{@redis_url}' \
-        --seed foobar \
-        --build 1 \
-        --worker 1 \
-        --timeout 1 \
-        --max-requeues 1  \
-        --requeue-tolerance 1  \
-        -Itest/fixtures \
-        test/fixtures/dummy_test.rb \
-      `.lines.last.strip)
+      out, err = capture_subprocess_io do
+        system(
+          'exe/minitest-queue',
+          '--retry',
+          '--url', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest/fixtures',
+          'test/fixtures/dummy_test.rb',
+        )
+      end
+      assert_empty err
+      output = normalize(out.lines.last.strip)
       assert_equal 'Ran 8 tests, 5 assertions, 1 failures, 1 errors, 1 skips, 3 requeues in X.XXs', output
     end
 
     def test_down_redis
-      output = normalize(`
-        exe/minitest-queue \
-        --url 'redis://localhost:1337/1' \
-        --seed foobar \
-        --build 1 \
-        --worker 1 \
-        --timeout 1 \
-        --max-requeues 1  \
-        --requeue-tolerance 1  \
-        -Itest/fixtures \
-        test/fixtures/dummy_test.rb \
-      `.lines.last.strip)
+      out, err = capture_subprocess_io do
+        system(
+          'exe/minitest-queue',
+          '--url', 'redis://localhost:1337',
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest/fixtures',
+          'test/fixtures/dummy_test.rb',
+        )
+      end
+      assert_empty err
+      output = normalize(out.lines.last.strip)
       assert_equal 'Ran 0 tests, 0 assertions, 0 failures, 0 errors, 0 skips, 0 requeues in X.XXs', output
     end
 
@@ -63,18 +97,22 @@ module Integration
         build_id: '1',
       )
 
-      output = normalize(`
-        exe/minitest-queue \
-        --url '#{@redis_url}' \
-        --seed foobar \
-        --build 1 \
-        --worker 1 \
-        --timeout 1 \
-        --max-requeues 1  \
-        --requeue-tolerance 1  \
-        -Itest/fixtures \
-        test/fixtures/dummy_test.rb \
-      `.lines.last.strip)
+      out, err = capture_subprocess_io do
+        system(
+          'exe/minitest-queue',
+          '--url', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest/fixtures',
+          'test/fixtures/dummy_test.rb',
+        )
+      end
+      assert_empty err
+      output = normalize(out.lines.last.strip)
       assert_equal 'Ran 8 tests, 5 assertions, 1 failures, 1 errors, 1 skips, 3 requeues in X.XXs', output
 
       io = StringIO.new
@@ -96,7 +134,7 @@ module Integration
     end
 
     private
-    
+
     def normalize(output)
       freeze_timing(decolorize_output(output))
     end


### PR DESCRIPTION
This way we can augment our output for known service providers while still being provider agnostic.

