### PR TITLE
Inffer a good seed from known CI providers

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -1,24 +1,33 @@
 module CI
   module Queue
     class Configuration
-      attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :requeue_tolerance, :namespace
+      attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :requeue_tolerance, :namespace, :seed
 
       class << self
         def from_env(env)
           new(
             build_id: env['CIRCLE_BUILD_URL'] || env['BUILDKITE_BUILD_ID'] || env['TRAVIS_BUILD_ID'],
             worker_id: env['CIRCLE_NODE_INDEX'] || env['BUILDKITE_PARALLEL_JOB'],
+            seed: env['CIRCLE_SHA1'] || env['BUILDKITE_COMMIT'] || env['TRAVIS_COMMIT'],
           )
         end
       end
 
-      def initialize(timeout: 10, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0, namespace: nil)
+      def initialize(
+        timeout: 10, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
+        namespace: nil, seed: nil
+      )
         @namespace = namespace
         @timeout = timeout
         @build_id = build_id
         @worker_id = worker_id
         @max_requeues = max_requeues
         @requeue_tolerance = requeue_tolerance
+        @seed = seed
+      end
+
+      def seed
+        @seed || build_id
       end
 
       def build_id

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -64,7 +64,7 @@ module Minitest
           end
 
           opts.on('--seed SEED') do |seed|
-            options[:seed] = seed
+            queue_config.seed = seed
           end
 
           opts.on('--timeout TIMEOUT') do |timeout|
@@ -95,8 +95,7 @@ module Minitest
       end
 
       def shuffle(tests)
-        seed = options.fetch(:seed, queue_config.build_id)
-        random = Random.new(Digest::MD5.hexdigest(seed).to_i(16))
+        random = Random.new(Digest::MD5.hexdigest(queue_config.seed).to_i(16))
         tests.shuffle(random: random)
       end
 

--- a/ruby/test/ci/queue/configuration_test.rb
+++ b/ruby/test/ci/queue/configuration_test.rb
@@ -6,25 +6,31 @@ module CI::Queue
       config = Configuration.from_env(
         'CIRCLE_BUILD_URL' => 'https://circleci.com/gh/circleci/frontend/933',
         'CIRCLE_NODE_INDEX' => '12',
+        'CIRCLE_SHA1' => 'faa647bbb8168a77cf338e7488c3f8445c3e6554',
       )
       assert_equal 'https://circleci.com/gh/circleci/frontend/933', config.build_id
       assert_equal '12', config.worker_id
+      assert_equal 'faa647bbb8168a77cf338e7488c3f8445c3e6554', config.seed
     end
 
     def test_buildkite_defaults
       config = Configuration.from_env(
         'BUILDKITE_BUILD_ID' => '9e08ef3c-d6e6-4a86-91dd-577ce5205b8e',
         'BUILDKITE_PARALLEL_JOB' => '12',
+        'BUILDKITE_COMMIT' => 'faa647bbb8168a77cf338e7488c3f8445c3e6554',
       )
       assert_equal '9e08ef3c-d6e6-4a86-91dd-577ce5205b8e', config.build_id
       assert_equal '12', config.worker_id
+      assert_equal 'faa647bbb8168a77cf338e7488c3f8445c3e6554', config.seed
     end
 
     def test_travis_defaults
       config = Configuration.from_env(
         'TRAVIS_BUILD_ID' => '324325435435',
+        'TRAVIS_COMMIT' => 'faa647bbb8168a77cf338e7488c3f8445c3e6554',
       )
       assert_equal '324325435435', config.build_id
+      assert_equal 'faa647bbb8168a77cf338e7488c3f8445c3e6554', config.seed
     end
 
     def test_namespace


### PR DESCRIPTION
Another setting that can easily be inferred on popular CI providers.

I'll document this later when I improve the `minitest-queue --help` output.