### PR TITLE
Add report subcommand to minitest-queue

### DIFF
--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -2,6 +2,7 @@ require 'uri'
 require 'cgi'
 
 require 'ci/queue/version'
+require 'ci/queue/output_helpers'
 require 'ci/queue/index'
 require 'ci/queue/configuration'
 require 'ci/queue/static'

--- a/ruby/lib/ci/queue/output_helpers.rb
+++ b/ruby/lib/ci/queue/output_helpers.rb
@@ -1,6 +1,10 @@
-module Minitest
-  module Reporters
+require 'ansi'
+
+module CI
+  module Queue
     module OutputHelpers
+      include ANSI::Code
+
       private
 
       def step(*args)
@@ -22,7 +26,6 @@ module Minitest
           DefaultOutput
         end
       end
-
 
       module DefaultOutput
         extend self

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -58,6 +58,10 @@ module CI
           Retry.new(log, config, redis: redis)
         end
 
+        def supervisor
+          Supervisor.new(redis_url, config)
+        end
+
         def minitest_reporters
           require 'minitest/reporters/queue_reporter'
           require 'minitest/reporters/redis_reporter'

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -24,6 +24,10 @@ module CI
         ]
       end
 
+      def supervisor
+        raise NotImplementedError, "This type of queue can't be supervised"
+      end
+
       def retry_queue
         self
       end

--- a/ruby/lib/minitest/reporters/failure_formatter.rb
+++ b/ruby/lib/minitest/reporters/failure_formatter.rb
@@ -1,4 +1,3 @@
-require 'ansi'
 require 'delegate'
 
 module Minitest

--- a/ruby/lib/minitest/reporters/queue_reporter.rb
+++ b/ruby/lib/minitest/reporters/queue_reporter.rb
@@ -1,11 +1,10 @@
+require 'ci/queue/output_helpers'
 require 'minitest/reporters'
-require 'minitest/reporters/output_helpers'
 
 module Minitest
   module Reporters
     class QueueReporter < BaseReporter
-      include ANSI::Code
-      include OutputHelpers
+      include ::CI::Queue::OutputHelpers
       attr_accessor :requeues
 
       def initialize(*)

--- a/ruby/lib/minitest/reporters/redis_reporter.rb
+++ b/ruby/lib/minitest/reporters/redis_reporter.rb
@@ -89,14 +89,18 @@ module Minitest
       end
 
       class Summary < Base
-        include ANSI::Code
+        include ::CI::Queue::OutputHelpers
 
-        def report(io: STDOUT)
-          io.puts aggregates
+        def report
+          puts aggregates
           errors = error_reports
-          io.puts errors
+          puts errors
 
           errors.empty?
+        end
+
+        def success?
+          errors == 0 && failures == 0
         end
 
         def record(*)
@@ -133,12 +137,12 @@ module Minitest
           success = failures.zero? && errors.zero?
           failures_count = "#{failures} failures, #{errors} errors,"
 
-          [
+          step([
             'Ran %d tests, %d assertions,' % [processed, assertions],
             success ? green(failures_count) : red(failures_count),
             yellow("#{skips} skips, #{requeues} requeues"),
             'in %.2fs (aggregated)' % total_time,
-          ].join(' ')
+          ].join(' '), collapsed: success)
         end
 
         def fetch_summary

--- a/ruby/test/support/output_test_helpers.rb
+++ b/ruby/test/support/output_test_helpers.rb
@@ -1,4 +1,4 @@
-module OutputHelpers
+module OutputTestHelpers
   private
 
   def decolorize_output(output)


### PR DESCRIPTION
This adds a `report` subcommand to `minitest-queue` which provides a decent default usage for `Redis::Supervisor` and `RedisReporter`.

e.g.:

```
$ BUILDKITE=1 RUBYLIB=lib/ exe/minitest-queue report --url 'redis://localhost' --build 1 --timeout 1
--- Waiting for workers to complete
+++ Ran 5 tests, 3 assertions, 2 failures, 1 errors, 1 skips, 1 requeues in 0.01s (aggregated)

FAIL ATest#test_bar
Expected false to be truthy.
    test/fixtures/dummy_test.rb:9:in `test_bar'

FAIL ATest#test_flaky
Expected false to be truthy.
    test/fixtures/dummy_test.rb:17:in `test_flaky'

ERROR BTest#test_bar
TypeError: String can't be coerced into Fixnum
    test/fixtures/dummy_test.rb:28:in `+'
    test/fixtures/dummy_test.rb:28:in `test_bar'
```
