### PR TITLE
Handle RSpec's ExampleGroup descendants (and fix shuffling)

### DIFF
--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -149,7 +149,7 @@ module RSpec
       end
 
       def run_specs(example_groups)
-        examples = example_groups.flat_map do |example_group|
+        examples = example_groups.flat_map(&:descendants).flat_map do |example_group|
           example_group.filtered_examples.map do |example|
             SingleExample.new(example_group, example)
           end

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -156,7 +156,7 @@ module RSpec
         end
 
         queue = CI::Queue.from_uri(queue_url, RSpec::Queue.config)
-        queue.populate(examples, &:id)
+        queue.populate(shuffle(examples), &:id)
         examples_count = examples.size # TODO: figure out which stub value would be best
         success = true
         @configuration.reporter.report(examples_count) do |reporter|
@@ -173,6 +173,12 @@ module RSpec
       end
 
       private
+
+      def shuffle(examples)
+        return examples unless RSpec::Queue.config.seed
+        random = Random.new(Digest::MD5.hexdigest(RSpec::Queue.config.seed).to_i(16))
+        examples.shuffle(random: random)
+      end
 
       def queue_url
         configuration.queue_url || ENV['CI_QUEUE_URL']

--- a/ruby/test/fixtures/spec/dummy_spec.rb
+++ b/ruby/test/fixtures/spec/dummy_spec.rb
@@ -6,4 +6,12 @@ RSpec.describe Object do
   it "doesn't work" do
     expect(1 + 1).to be == 42
   end
+
+  describe 'some sublclass' do
+
+    it "should be ran as well" do
+      expect(1 + 1).to be == 2
+    end
+
+  end
 end

--- a/ruby/test/integration/rspec_redis_test.rb
+++ b/ruby/test/integration/rspec_redis_test.rb
@@ -31,7 +31,7 @@ module Integration
       expected_output = strip_heredoc <<-EOS
 
         Randomized with seed 123
-        .F
+        .F.
 
         Failures:
 
@@ -43,7 +43,7 @@ module Integration
              # ./spec/dummy_spec.rb:7:in `block (2 levels) in <top (required)>'
 
         Finished in X.XXXXX seconds (files took X.XXXXX seconds to load)
-        2 examples, 1 failure
+        3 examples, 1 failure
 
         Failed examples:
 

--- a/ruby/test/integration/rspec_redis_test.rb
+++ b/ruby/test/integration/rspec_redis_test.rb
@@ -14,7 +14,7 @@ module Integration
     def test_redis_runner
       out, err = capture_subprocess_io do
         system(
-          { 'BUILDKITE' => '1' },
+          { 'BUILDKITE' => '1', 'BUILDKITE_COMMIT' => 'aaaaaaaaaaaaa' },
           @exe,
           '--queue', @redis_url,
           '--seed', '123',
@@ -31,7 +31,7 @@ module Integration
       expected_output = strip_heredoc <<-EOS
 
         Randomized with seed 123
-        .F.
+        ..F
 
         Failures:
 


### PR DESCRIPTION
It's a bit contrived IMO, but turns out the `example_groups` list is not enough, each of them have "descendants" (nested describes), that you have to iterate over as well.

I also realized I forgot to implement test shuffling for RSpec....

