### PR TITLE
Built-in SnappyPack codec

### DIFF
--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -35,4 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redis', '~> 3.3'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'minitest-reporters', '~> 1.1'
+
+  spec.add_development_dependency 'snappy'
+  spec.add_development_dependency 'msgpack'
 end

--- a/ruby/test/minitest/reporters/redis_reporter_test.rb
+++ b/ruby/test/minitest/reporters/redis_reporter_test.rb
@@ -45,6 +45,17 @@ module Minitest::Reporters
       assert_equal 0, summary.error_reports.size
     end
 
+    def test_default_coder
+      assert defined? RedisReporter::Error::SnappyPack
+      assert_equal RedisReporter::Error::SnappyPack, RedisReporter::Error.coder
+    end
+
+    def test_snappypack_coder
+      original_hash = {foo: 'bar'}
+      round_trip = RedisReporter::Error.coder.load(RedisReporter::Error.coder.dump(original_hash))
+      assert_equal original_hash, round_trip
+    end
+
     private
 
     def worker(id)


### PR DESCRIPTION
We've seen a 78% reduction is memory usage when we enabled this on out application, so might as well provide it automatically in the gem.

However `snappy` and `msgpack` both being native gems, I'd rather not force the dependency. The optimization will be enabled automatically if the project uses those already. Otherwise it will fallback to `Marshal`.