### PR TITLE
Fix a bug introduced in Python3 compatibility, where the reporter could not start before its workers.

### DIFF
--- a/python/ciqueue/distributed.py
+++ b/python/ciqueue/distributed.py
@@ -40,7 +40,8 @@ class Base(object):
             "` after {} seconds waiting.".format(timeout))
 
     def _master_status(self):
-        return self.redis.get(self.key('master-status')).decode()
+        raw = self.redis.get(self.key('master-status'))
+        return raw.decode() if raw else None
 
     def __len__(self):
         transaction = self.redis.pipeline(transaction=True)

--- a/python/tests/test_distributed.py
+++ b/python/tests/test_distributed.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import redis
 from ciqueue import distributed
 from tests import shared
@@ -23,6 +24,9 @@ class TestDistributed(shared.QueueImplementation):
             max_requeues=1,
             requeue_tolerance=0.1,
         )
+
+    def build_supervisor(self):
+        return distributed.Supervisor(redis=self._redis, build_id=42)
 
     def test_requeue(self):
         assert self.requeue() == self.TEST_LIST + [self.TEST_LIST[0]]
@@ -52,3 +56,13 @@ class TestDistributed(shared.QueueImplementation):
 
         second_queue = self.build_queue(1)
         assert not second_queue.is_master
+
+    def test_supervisor_before_worker(self):
+        supervisor = self.build_supervisor()
+
+        with pytest.raises(distributed.LostMaster):
+            supervisor.wait_for_master(timeout=0)
+
+        first_queue = self.build_queue(1)
+
+        assert supervisor.wait_for_master(timeout=0)

--- a/python/tests/test_distributed.py
+++ b/python/tests/test_distributed.py
@@ -63,6 +63,6 @@ class TestDistributed(shared.QueueImplementation):
         with pytest.raises(distributed.LostMaster):
             supervisor.wait_for_master(timeout=0)
 
-        first_queue = self.build_queue(1)
+        self.build_queue(1)
 
         assert supervisor.wait_for_master(timeout=0)


### PR DESCRIPTION
@solackerman PTAL.

I added a test case that at least makes sure that the expected exception is thrown when a wait_for_master times out. There's no easy way, right now, to test that `wait_for_master` eventually does the right thing when the master isn't there the first time but then shows up later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shopify/ci-queue/51)
<!-- Reviewable:end -->
