### PR TITLE
Refactor travis test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ services:
 language: ruby
 rvm:
   - '2.3'
+env:
+  - SUITE=python
+  - SUITE=ruby
 before_install:
-  - gem install bundler -v 1.5.1
-  - cd python
-  - sudo pip install -U pip
-  - sudo pip install setuptools==33.1.1
-  - pip --version
-  - sudo make install
-  - cd ../ruby
+  - bin/before-install
 script:
-  - cd ../ruby && bundle exec rake
-  - cd ../python && PYTHONPATH='.' sudo make test
+  - bin/test

--- a/bin/before-install
+++ b/bin/before-install
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+def run(*args)
+  puts "$ #{args.join(' ')}"
+  unless system(*args)
+    exit $?.exitstatus
+  end
+end
+
+case ENV['SUITE']
+when 'python'
+  Dir.chdir('python/') do
+    run('sudo', 'pip', 'install', '-U', 'pip')
+    run('sudo', 'pip', 'install', 'setuptools==33.1.1')
+    run('pip', '--version')
+    run('sudo', 'make', 'install')
+  end
+when 'ruby'
+  run('gem', 'install', 'bundler', '-v', '1.5.1')
+else
+  abort("Missing or invalid SUITE environment variable")
+end

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+def run(*args)
+  puts "$ #{args.join(' ')}"
+  unless system(*args)
+    exit $?.exitstatus
+  end
+end
+
+case ENV['SUITE']
+when 'python'
+  Dir.chdir('python/') do
+    run({ 'PYTHONPATH' => '.' }, 'sudo', 'make', 'test')
+  end
+when 'ruby'
+  Dir.chdir('ruby/') do
+    run('bundle', 'install')
+    run('bundle', 'exec', 'rake')
+  end
+else
+  abort("Missing or invalid SUITE environment variable")
+end


### PR DESCRIPTION
Context: Minitest 5.11 was released early this year, and broke the monkey patch we use in ci-queue to implement requeues. So in order to support both versions of minitest we'll need to test both on CI.

Because of this I decided to refactor the `travis.yml` a bit to makes testing 2 versions of minitest easier.