### PR TITLE
Fix Minitest 5.11 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
 env:
   - SUITE=python
   - SUITE=ruby
+  - SUITE=ruby MINITEST_VERSION=5.9.1
 before_install:
   - bin/before-install
 script:

--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', "~> 10.0"
-  spec.add_development_dependency 'minitest', '~> 5.9.1'
+  spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'redis', '~> 3.3'
   spec.add_development_dependency 'simplecov', '~> 0.12'

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -116,4 +116,9 @@ module Minitest
 end
 
 MiniTest.singleton_class.prepend(MiniTest::Queue)
-MiniTest::Test.prepend(MiniTest::Requeueing)
+if defined? MiniTest::Result
+  MiniTest::Result.prepend(MiniTest::Requeueing)
+else
+  MiniTest::Test.prepend(MiniTest::Requeueing)
+  MiniTest::Test.send(:alias_method, :klass, :class)
+end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -2,6 +2,7 @@ require 'optparse'
 require 'minitest/queue'
 require 'ci/queue'
 require 'digest/md5'
+require 'minitest/reporters/bisect_reporter'
 
 module Minitest
   module Queue
@@ -61,7 +62,7 @@ module Minitest
         step("Testing the failing test in isolation")
         unless run_tests_in_fork(queue.failing_test)
           puts reopen_previous_step
-          puts red("The test fail when run alone, no need to bisect.")
+          puts red("The test fail when ran alone, no need to bisect.")
           exit! 0
         end
 
@@ -130,7 +131,7 @@ module Minitest
       def run_tests_in_fork(queue)
         child_pid = fork do
           Minitest.queue = queue
-          Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
+          Minitest::Reporters.use!([Minitest::Reporters::BisectReporter.new])
           exit # let minitest excute its at_exit
         end
 

--- a/ruby/lib/minitest/reporters/bisect_reporter.rb
+++ b/ruby/lib/minitest/reporters/bisect_reporter.rb
@@ -1,0 +1,16 @@
+require 'minitest/reporters'
+
+module Minitest
+  module Reporters
+    class BisectReporter < BaseReporter
+      include RelativePosition
+
+      def record(test)
+        super
+        test_name = "#{test.klass}##{test.name}"
+        print pad_test(test_name)
+        puts pad_mark(result(test).to_s.upcase)
+      end
+    end
+  end
+end

--- a/ruby/lib/minitest/reporters/failure_formatter.rb
+++ b/ruby/lib/minitest/reporters/failure_formatter.rb
@@ -20,7 +20,7 @@ module Minitest
 
       def to_h
         {
-          test_and_module_name: "#{test.class}##{test.name}",
+          test_and_module_name: "#{test.klass}##{test.name}",
           test_name: test.name,
           output: to_s,
         }
@@ -31,7 +31,7 @@ module Minitest
       attr_reader :test
 
       def header
-        "#{red(status)} #{test.class}##{test.name}"
+        "#{red(status)} #{test.klass}##{test.name}"
       end
 
       def status

--- a/ruby/lib/minitest/reporters/order_reporter.rb
+++ b/ruby/lib/minitest/reporters/order_reporter.rb
@@ -13,7 +13,7 @@ class Minitest::Reporters::OrderReporter < Minitest::Reporters::BaseReporter
 
   def before_test(test)
     super
-    @file.puts("#{test.class}##{test.name}")
+    @file.puts("#{test.klass}##{test.name}")
   end
 
   def report

--- a/ruby/lib/minitest/reporters/queue_reporter.rb
+++ b/ruby/lib/minitest/reporters/queue_reporter.rb
@@ -36,7 +36,7 @@ module Minitest
         e = test.failure
 
         if test.requeued?
-          "Requeued:\n#{test.class}##{test.name} [#{location(e)}]:\n#{e.message}"
+          "Requeued:\n#{test.klass}##{test.name} [#{location(e)}]:\n#{e.message}"
         else
           super
         end

--- a/ruby/lib/minitest/reporters/redis_reporter.rb
+++ b/ruby/lib/minitest/reporters/redis_reporter.rb
@@ -217,9 +217,9 @@ module Minitest
 
           redis.multi do
             if (test.failure || test.error?) && !test.skipped?
-              redis.hset(key('error-reports'), "#{test.class}##{test.name}", dump(test))
+              redis.hset(key('error-reports'), "#{test.klass}##{test.name}", dump(test))
             else
-              redis.hdel(key('error-reports'), "#{test.class}##{test.name}")
+              redis.hdel(key('error-reports'), "#{test.klass}##{test.name}")
             end
             COUNTERS.each do |counter|
               redis.hset(key(counter), worker_id, send(counter))

--- a/ruby/test/integration/minitest_bisect_test.rb
+++ b/ruby/test/integration/minitest_bisect_test.rb
@@ -12,139 +12,75 @@ module Integration
       assert_empty err
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_sensible_to_leak                                 PASS
         --- Run #1, 45 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_0                                                  PASS (X.XXs)
-          test_useless_1                                                  PASS (X.XXs)
-          test_useless_2                                                  PASS (X.XXs)
-          test_useless_3                                                  PASS (X.XXs)
-          test_useless_4                                                  PASS (X.XXs)
-          test_useless_5                                                  PASS (X.XXs)
-          test_useless_6                                                  PASS (X.XXs)
-          test_useless_7                                                  PASS (X.XXs)
-          test_useless_8                                                  PASS (X.XXs)
-          test_useless_9                                                  PASS (X.XXs)
-          test_introduce_leak                                             PASS (X.XXs)
-          test_useless_10                                                 PASS (X.XXs)
-          test_useless_11                                                 PASS (X.XXs)
-          test_useless_12                                                 PASS (X.XXs)
-          test_useless_13                                                 PASS (X.XXs)
-          test_useless_14                                                 PASS (X.XXs)
-          test_useless_15                                                 PASS (X.XXs)
-          test_useless_16                                                 PASS (X.XXs)
-          test_useless_17                                                 PASS (X.XXs)
-          test_useless_18                                                 PASS (X.XXs)
-          test_useless_19                                                 PASS (X.XXs)
-          test_useless_20                                                 PASS (X.XXs)
-          test_useless_21                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           FAIL (X.XXs)
-        Minitest::Assertion:         Expected: false
-                  Actual: true
-                ./test/fixtures/test/leaky_test.rb:24:in `test_sensible_to_leak'
-
-
-        Finished in X.XXs
-        24 tests, 24 assertions, 1 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_0                                        PASS
+          LeakyTest#test_useless_1                                        PASS
+          LeakyTest#test_useless_2                                        PASS
+          LeakyTest#test_useless_3                                        PASS
+          LeakyTest#test_useless_4                                        PASS
+          LeakyTest#test_useless_5                                        PASS
+          LeakyTest#test_useless_6                                        PASS
+          LeakyTest#test_useless_7                                        PASS
+          LeakyTest#test_useless_8                                        PASS
+          LeakyTest#test_useless_9                                        PASS
+          LeakyTest#test_introduce_leak                                   PASS
+          LeakyTest#test_useless_10                                       PASS
+          LeakyTest#test_useless_11                                       PASS
+          LeakyTest#test_useless_12                                       PASS
+          LeakyTest#test_useless_13                                       PASS
+          LeakyTest#test_useless_14                                       PASS
+          LeakyTest#test_useless_15                                       PASS
+          LeakyTest#test_useless_16                                       PASS
+          LeakyTest#test_useless_17                                       PASS
+          LeakyTest#test_useless_18                                       PASS
+          LeakyTest#test_useless_19                                       PASS
+          LeakyTest#test_useless_20                                       PASS
+          LeakyTest#test_useless_21                                       PASS
+          LeakyTest#test_sensible_to_leak                                 FAIL
 
         --- Run #2, 23 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_0                                                  PASS (X.XXs)
-          test_useless_1                                                  PASS (X.XXs)
-          test_useless_2                                                  PASS (X.XXs)
-          test_useless_3                                                  PASS (X.XXs)
-          test_useless_4                                                  PASS (X.XXs)
-          test_useless_5                                                  PASS (X.XXs)
-          test_useless_6                                                  PASS (X.XXs)
-          test_useless_7                                                  PASS (X.XXs)
-          test_useless_8                                                  PASS (X.XXs)
-          test_useless_9                                                  PASS (X.XXs)
-          test_introduce_leak                                             PASS (X.XXs)
-          test_useless_10                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           FAIL (X.XXs)
-        Minitest::Assertion:         Expected: false
-                  Actual: true
-                ./test/fixtures/test/leaky_test.rb:24:in `test_sensible_to_leak'
-
-
-        Finished in X.XXs
-        13 tests, 13 assertions, 1 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_0                                        PASS
+          LeakyTest#test_useless_1                                        PASS
+          LeakyTest#test_useless_2                                        PASS
+          LeakyTest#test_useless_3                                        PASS
+          LeakyTest#test_useless_4                                        PASS
+          LeakyTest#test_useless_5                                        PASS
+          LeakyTest#test_useless_6                                        PASS
+          LeakyTest#test_useless_7                                        PASS
+          LeakyTest#test_useless_8                                        PASS
+          LeakyTest#test_useless_9                                        PASS
+          LeakyTest#test_introduce_leak                                   PASS
+          LeakyTest#test_useless_10                                       PASS
+          LeakyTest#test_sensible_to_leak                                 FAIL
 
         --- Run #3, 12 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_0                                                  PASS (X.XXs)
-          test_useless_1                                                  PASS (X.XXs)
-          test_useless_2                                                  PASS (X.XXs)
-          test_useless_3                                                  PASS (X.XXs)
-          test_useless_4                                                  PASS (X.XXs)
-          test_useless_5                                                  PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        7 tests, 7 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_0                                        PASS
+          LeakyTest#test_useless_1                                        PASS
+          LeakyTest#test_useless_2                                        PASS
+          LeakyTest#test_useless_3                                        PASS
+          LeakyTest#test_useless_4                                        PASS
+          LeakyTest#test_useless_5                                        PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Run #4, 6 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_6                                                  PASS (X.XXs)
-          test_useless_7                                                  PASS (X.XXs)
-          test_useless_8                                                  PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        4 tests, 4 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_6                                        PASS
+          LeakyTest#test_useless_7                                        PASS
+          LeakyTest#test_useless_8                                        PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Run #5, 3 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_9                                                  PASS (X.XXs)
-          test_introduce_leak                                             PASS (X.XXs)
-          test_sensible_to_leak                                           FAIL (X.XXs)
-        Minitest::Assertion:         Expected: false
-                  Actual: true
-                ./test/fixtures/test/leaky_test.rb:24:in `test_sensible_to_leak'
-
-
-        Finished in X.XXs
-        3 tests, 3 assertions, 1 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_9                                        PASS
+          LeakyTest#test_introduce_leak                                   PASS
+          LeakyTest#test_sensible_to_leak                                 FAIL
 
         --- Run #6, 2 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_9                                                  PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        2 tests, 2 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_9                                        PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Final validation
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_introduce_leak                                             PASS (X.XXs)
-          test_sensible_to_leak                                           FAIL (X.XXs)
-        Minitest::Assertion:         Expected: false
-                  Actual: true
-                ./test/fixtures/test/leaky_test.rb:24:in `test_sensible_to_leak'
-
-
-        Finished in X.XXs
-        2 tests, 2 assertions, 1 failures, 0 errors, 0 skips
+          LeakyTest#test_introduce_leak                                   PASS
+          LeakyTest#test_sensible_to_leak                                 FAIL
         +++ The following command should reproduce the leak on your machine:
 
         cat <<EOF |
@@ -166,111 +102,69 @@ module Integration
       assert_empty err
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_sensible_to_leak                                 PASS
         --- Run #1, 45 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_0                                                  PASS (X.XXs)
-          test_useless_1                                                  PASS (X.XXs)
-          test_useless_2                                                  PASS (X.XXs)
-          test_useless_3                                                  PASS (X.XXs)
-          test_useless_4                                                  PASS (X.XXs)
-          test_useless_5                                                  PASS (X.XXs)
-          test_useless_6                                                  PASS (X.XXs)
-          test_useless_7                                                  PASS (X.XXs)
-          test_useless_8                                                  PASS (X.XXs)
-          test_useless_9                                                  PASS (X.XXs)
-          test_harmless_test                                              PASS (X.XXs)
-          test_useless_10                                                 PASS (X.XXs)
-          test_useless_11                                                 PASS (X.XXs)
-          test_useless_12                                                 PASS (X.XXs)
-          test_useless_13                                                 PASS (X.XXs)
-          test_useless_14                                                 PASS (X.XXs)
-          test_useless_15                                                 PASS (X.XXs)
-          test_useless_16                                                 PASS (X.XXs)
-          test_useless_17                                                 PASS (X.XXs)
-          test_useless_18                                                 PASS (X.XXs)
-          test_useless_19                                                 PASS (X.XXs)
-          test_useless_20                                                 PASS (X.XXs)
-          test_useless_21                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        24 tests, 24 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_0                                        PASS
+          LeakyTest#test_useless_1                                        PASS
+          LeakyTest#test_useless_2                                        PASS
+          LeakyTest#test_useless_3                                        PASS
+          LeakyTest#test_useless_4                                        PASS
+          LeakyTest#test_useless_5                                        PASS
+          LeakyTest#test_useless_6                                        PASS
+          LeakyTest#test_useless_7                                        PASS
+          LeakyTest#test_useless_8                                        PASS
+          LeakyTest#test_useless_9                                        PASS
+          LeakyTest#test_harmless_test                                    PASS
+          LeakyTest#test_useless_10                                       PASS
+          LeakyTest#test_useless_11                                       PASS
+          LeakyTest#test_useless_12                                       PASS
+          LeakyTest#test_useless_13                                       PASS
+          LeakyTest#test_useless_14                                       PASS
+          LeakyTest#test_useless_15                                       PASS
+          LeakyTest#test_useless_16                                       PASS
+          LeakyTest#test_useless_17                                       PASS
+          LeakyTest#test_useless_18                                       PASS
+          LeakyTest#test_useless_19                                       PASS
+          LeakyTest#test_useless_20                                       PASS
+          LeakyTest#test_useless_21                                       PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Run #2, 22 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_22                                                 PASS (X.XXs)
-          test_useless_23                                                 PASS (X.XXs)
-          test_useless_24                                                 PASS (X.XXs)
-          test_useless_25                                                 PASS (X.XXs)
-          test_useless_26                                                 PASS (X.XXs)
-          test_useless_27                                                 PASS (X.XXs)
-          test_useless_28                                                 PASS (X.XXs)
-          test_useless_29                                                 PASS (X.XXs)
-          test_useless_30                                                 PASS (X.XXs)
-          test_useless_31                                                 PASS (X.XXs)
-          test_useless_32                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        12 tests, 12 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_22                                       PASS
+          LeakyTest#test_useless_23                                       PASS
+          LeakyTest#test_useless_24                                       PASS
+          LeakyTest#test_useless_25                                       PASS
+          LeakyTest#test_useless_26                                       PASS
+          LeakyTest#test_useless_27                                       PASS
+          LeakyTest#test_useless_28                                       PASS
+          LeakyTest#test_useless_29                                       PASS
+          LeakyTest#test_useless_30                                       PASS
+          LeakyTest#test_useless_31                                       PASS
+          LeakyTest#test_useless_32                                       PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Run #3, 11 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_33                                                 PASS (X.XXs)
-          test_useless_34                                                 PASS (X.XXs)
-          test_useless_35                                                 PASS (X.XXs)
-          test_useless_36                                                 PASS (X.XXs)
-          test_useless_37                                                 PASS (X.XXs)
-          test_useless_38                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        7 tests, 7 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_33                                       PASS
+          LeakyTest#test_useless_34                                       PASS
+          LeakyTest#test_useless_35                                       PASS
+          LeakyTest#test_useless_36                                       PASS
+          LeakyTest#test_useless_37                                       PASS
+          LeakyTest#test_useless_38                                       PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Run #4, 5 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_39                                                 PASS (X.XXs)
-          test_useless_40                                                 PASS (X.XXs)
-          test_useless_41                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        4 tests, 4 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_39                                       PASS
+          LeakyTest#test_useless_40                                       PASS
+          LeakyTest#test_useless_41                                       PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Run #5, 2 suspects left
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_42                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        2 tests, 2 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_42                                       PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
 
         --- Final validation
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_useless_43                                                 PASS (X.XXs)
-          test_sensible_to_leak                                           PASS (X.XXs)
-
-        Finished in X.XXs
-        2 tests, 2 assertions, 0 failures, 0 errors, 0 skips
+          LeakyTest#test_useless_43                                       PASS
+          LeakyTest#test_sensible_to_leak                                 PASS
         --- The bisection was inconclusive, there might not be any leaky test here.
       EOS
 
@@ -285,19 +179,10 @@ module Integration
       assert_empty err
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
-        Started with run options --seed XXXXX
-
-        LeakyTest
-          test_broken_test                                                FAIL (X.XXs)
-        Minitest::Assertion:         Expected false to be truthy.
-                ./test/fixtures/test/leaky_test.rb:32:in `test_broken_test'
-
-
-        Finished in X.XXs
-        1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
+          LeakyTest#test_broken_test                                      FAIL
         ^^^ +++
 
-        The test fail when run alone, no need to bisect.
+        The test fail when ran alone, no need to bisect.
       EOS
 
       assert_equal expected_output, normalize(out)

--- a/ruby/test/support/reporter_test_helper.rb
+++ b/ruby/test/support/reporter_test_helper.rb
@@ -3,6 +3,9 @@ module ReporterTestHelper
 
   def runnable(name, failure = nil)
     runnable = Minitest::Test.new(name)
+    if defined? Minitest::Result
+      runnable = Minitest::Result.from(runnable)
+    end
     runnable.failures << failure if failure
     runnable.assertions += 1
     runnable


### PR DESCRIPTION
  Minitest 5.11 was released a week ago, and changed the internals significantly breaking compatibility with most reporters out there (`minitest-reporters` included).

This PR test and support both 5.11 and previous versions.