### PR TITLE
Refactor to get rid of #minitest_reporter methods on Queue implementations

### DIFF
--- a/ruby/lib/ci/queue/redis/retry.rb
+++ b/ruby/lib/ci/queue/redis/retry.rb
@@ -11,15 +11,6 @@ module CI
           @build ||= CI::Queue::Redis::BuildRecord.new(self, redis, config)
         end
 
-        def minitest_reporters
-          require 'minitest/reporters/queue_reporter'
-          require 'minitest/reporters/redis_reporter'
-          @minitest_reporters ||= [
-            Minitest::Reporters::QueueReporter.new,
-            Minitest::Reporters::RedisReporter::Worker.new(build: build),
-          ]
-        end
-
         private
 
         attr_reader :redis

--- a/ruby/lib/ci/queue/redis/supervisor.rb
+++ b/ruby/lib/ci/queue/redis/supervisor.rb
@@ -15,13 +15,6 @@ module CI
           @build ||= CI::Queue::Redis::BuildRecord.new(self, redis, config)
         end
 
-        def minitest_reporters
-          require 'minitest/reporters/redis_reporter'
-          @reporters ||= [
-            Minitest::Reporters::RedisReporter::Summary.new(build: build)
-          ]
-        end
-
         def wait_for_workers
           return false unless wait_for_master(timeout: config.timeout)
 

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -67,15 +67,6 @@ module CI
           @build ||= CI::Queue::Redis::BuildRecord.new(self, redis, config)
         end
 
-        def minitest_reporters
-          require 'minitest/reporters/queue_reporter'
-          require 'minitest/reporters/redis_reporter'
-          @minitest_reporters ||= [
-            Minitest::Reporters::QueueReporter.new,
-            Minitest::Reporters::RedisReporter::Worker.new(build: build)
-          ]
-        end
-
         def acknowledge(test)
           test_key = test.id
           raise_on_mismatching_test(test_key)

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -21,13 +21,6 @@ module CI
         @build ||= BuildRecord.new(self)
       end
 
-      def minitest_reporters
-        require 'minitest/reporters/queue_reporter'
-        @minitest_reporters ||= [
-          Minitest::Reporters::QueueReporter.new,
-        ]
-      end
-
       def supervisor
         raise NotImplementedError, "This type of queue can't be supervised"
       end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -1,7 +1,13 @@
 require 'minitest'
-
 gem 'minitest-reporters', '~> 1.1'
 require 'minitest/reporters'
+
+require 'minitest/queue/failure_formatter'
+require 'minitest/queue/error_report'
+require 'minitest/queue/local_requeue_reporter'
+require 'minitest/queue/build_status_recorder'
+require 'minitest/queue/build_status_reporter'
+
 
 module Minitest
   class Requeue < Skip
@@ -68,11 +74,6 @@ module Minitest
 
     def queue=(queue)
       @queue = queue
-      if queue.respond_to?(:minitest_reporters)
-        self.queue_reporters = queue.minitest_reporters
-      else
-        self.queue_reporters = []
-      end
     end
 
     def queue_reporters=(reporters)

--- a/ruby/lib/minitest/queue/build_status_recorder.rb
+++ b/ruby/lib/minitest/queue/build_status_recorder.rb
@@ -1,0 +1,68 @@
+require 'minitest/reporters'
+
+module Minitest
+  module Queue
+    class BuildStatusRecorder < Minitest::Reporters::BaseReporter
+      COUNTERS = %w(
+        assertions
+        errors
+        failures
+        skips
+        requeues
+        total_time
+      ).freeze
+
+      class << self
+        attr_accessor :failure_formatter
+      end
+      self.failure_formatter = FailureFormatter
+
+      attr_accessor :requeues
+
+      def initialize(build:, **options)
+        super(options)
+
+        @build = build
+        self.failures = 0
+        self.errors = 0
+        self.skips = 0
+        self.requeues = 0
+      end
+
+      def report
+        # noop
+      end
+
+      def record(test)
+        super
+
+        self.total_time = Minitest.clock_time - start_time
+        if test.requeued?
+          self.requeues += 1
+        elsif test.skipped?
+          self.skips += 1
+        elsif test.error?
+          self.errors += 1
+        elsif test.failure
+          self.failures += 1
+        end
+
+
+        stats = COUNTERS.zip(COUNTERS.map { |c| send(c) })
+        if (test.failure || test.error?) && !test.skipped?
+          build.record_error("#{test.klass}##{test.name}", dump(test), stats: stats)
+        else
+          build.record_success("#{test.klass}##{test.name}", stats: stats)
+        end
+      end
+
+      private
+
+      def dump(test)
+        ErrorReport.new(self.class.failure_formatter.new(test).to_h).dump
+      end
+
+      attr_reader :build
+    end
+  end
+end

--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -1,0 +1,84 @@
+module Minitest
+  module Queue
+    class BuildStatusReporter < Minitest::Reporters::BaseReporter
+      include ::CI::Queue::OutputHelpers
+
+      def initialize(build:, **options)
+        @build = build
+        super(options)
+      end
+
+      def completed?
+        build.queue_exhausted?
+      end
+
+      def error_reports
+        build.error_reports.sort_by(&:first).map { |k, v| ErrorReport.load(v) }
+      end
+
+      def report
+        puts aggregates
+        errors = error_reports
+        puts errors
+
+        errors.empty?
+      end
+
+      def success?
+        errors == 0 && failures == 0
+      end
+
+      def record(*)
+        raise NotImplementedError
+      end
+
+      def failures
+        fetch_summary['failures'].to_i
+      end
+
+      def errors
+        fetch_summary['errors'].to_i
+      end
+
+      def assertions
+        fetch_summary['assertions'].to_i
+      end
+
+      def skips
+        fetch_summary['skips'].to_i
+      end
+
+      def requeues
+        fetch_summary['requeues'].to_i
+      end
+
+      def total_time
+        fetch_summary['total_time'].to_f
+      end
+
+      def progress
+        build.progress
+      end
+
+      private
+
+      attr_reader :build
+
+      def aggregates
+        success = failures.zero? && errors.zero?
+        failures_count = "#{failures} failures, #{errors} errors,"
+
+        step([
+          'Ran %d tests, %d assertions,' % [progress, assertions],
+          success ? green(failures_count) : red(failures_count),
+          yellow("#{skips} skips, #{requeues} requeues"),
+          'in %.2fs (aggregated)' % total_time,
+        ].join(' '), collapsed: success)
+      end
+
+      def fetch_summary
+        @summary ||= build.fetch_stats(BuildStatusRecorder::COUNTERS)
+      end
+    end
+  end
+end

--- a/ruby/lib/minitest/queue/error_report.rb
+++ b/ruby/lib/minitest/queue/error_report.rb
@@ -1,0 +1,69 @@
+module Minitest
+  module Queue
+    class ErrorReport
+      class << self
+        attr_accessor :coder
+
+        def load(payload)
+          new(coder.load(payload))
+        end
+      end
+
+      self.coder = Marshal
+
+      begin
+        require 'snappy'
+        require 'msgpack'
+        require 'stringio'
+
+        module SnappyPack
+          extend self
+
+          MSGPACK = MessagePack::Factory.new
+          MSGPACK.register_type(0x00, Symbol)
+
+          def load(payload)
+            io = StringIO.new(Snappy.inflate(payload))
+            MSGPACK.unpacker(io).unpack
+          end
+
+          def dump(object)
+            io = StringIO.new
+            packer = MSGPACK.packer(io)
+            packer.pack(object)
+            packer.flush
+            io.rewind
+            Snappy.deflate(io.string).force_encoding(Encoding::UTF_8)
+          end
+        end
+
+        self.coder = SnappyPack
+      rescue LoadError
+      end
+
+      def initialize(data)
+        @data = data
+      end
+
+      def dump
+        self.class.coder.dump(@data)
+      end
+
+      def test_name
+        @data[:test_name]
+      end
+
+      def test_and_module_name
+        @data[:test_and_module_name]
+      end
+
+      def to_s
+        output
+      end
+
+      def output
+        @data[:output]
+      end
+    end
+  end
+end

--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -1,7 +1,8 @@
 require 'delegate'
+require 'ansi'
 
 module Minitest
-  module Reporters
+  module Queue
     class FailureFormatter < SimpleDelegator
       include ANSI::Code
 

--- a/ruby/lib/minitest/queue/local_requeue_reporter.rb
+++ b/ruby/lib/minitest/queue/local_requeue_reporter.rb
@@ -2,8 +2,8 @@ require 'ci/queue/output_helpers'
 require 'minitest/reporters'
 
 module Minitest
-  module Reporters
-    class QueueReporter < BaseReporter
+  module Queue
+    class LocalRequeueReporter < Minitest::Reporters::BaseReporter
       include ::CI::Queue::OutputHelpers
       attr_accessor :requeues
 

--- a/ruby/test/minitest/queue/build_status_recorder.rb
+++ b/ruby/test/minitest/queue/build_status_recorder.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-module Minitest::Reporters
-  class RedisReporterTest < Minitest::Test
+module Minitest::Queue
+  class BuildStatusRecorderTest < Minitest::Test
     include ReporterTestHelper
 
     def setup
@@ -9,7 +9,7 @@ module Minitest::Reporters
       @redis = ::Redis.new(url: @redis_url)
       @redis.flushdb
       @queue = worker(1)
-      @reporter = @queue.minitest_reporters.last
+      @reporter = BuildStatusRecorder.new(build: @queue.build)
       @reporter.start
     end
 
@@ -43,17 +43,6 @@ module Minitest::Reporters
 
       second_reporter.record(result('a'))
       assert_equal 0, summary.error_reports.size
-    end
-
-    def test_default_coder
-      assert defined? RedisReporter::Error::SnappyPack
-      assert_equal RedisReporter::Error::SnappyPack, RedisReporter::Error.coder
-    end
-
-    def test_snappypack_coder
-      original_hash = {foo: 'bar'}
-      round_trip = RedisReporter::Error.coder.load(RedisReporter::Error.coder.dump(original_hash))
-      assert_equal original_hash, round_trip
     end
 
     private

--- a/ruby/test/minitest/queue/error_report_test.rb
+++ b/ruby/test/minitest/queue/error_report_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module Minitest
+  module Queue
+    class ErrorReportTest < Minitest::Test
+      def test_default_coder
+        assert defined? Minitest::Queue::ErrorReport::SnappyPack
+        assert_equal Minitest::Queue::ErrorReport::SnappyPack, Minitest::Queue::ErrorReport.coder
+      end
+
+      def test_snappypack_coder
+        original_hash = {foo: 'bar'}
+        round_trip = Minitest::Queue::ErrorReport.coder.load(Minitest::Queue::ErrorReport.coder.dump(original_hash))
+        assert_equal original_hash, round_trip
+      end
+    end
+  end
+end

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -7,7 +7,6 @@ ENV['PATH'] = "#{File.expand_path('../../exe/', __FILE__)}:#{ENV['PATH']}"
 require 'ci/queue'
 require 'ci/queue/redis'
 require 'minitest/queue'
-require 'minitest/reporters/redis_reporter'
 require 'minitest/reporters/order_reporter'
 require 'minitest/autorun'
 


### PR DESCRIPTION
Followup to https://github.com/Shopify/ci-queue/pull/54

While convenient, these methods where coupling queue implementations with Minitest which is kind of messed up. Also that idea of having reporters matching a queue kind of broke down with the bisect command, and is made unnecessary by #54 since queues now expose a common interface to report build progress and status.

So 🔥 