### PR TITLE
Implement requeueing for RSpec

### DIFF
--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -80,11 +80,12 @@ module CI
         def requeue(test, offset: Redis.requeue_offset)
           test_key = test.id
           raise_on_mismatching_test(test_key)
+          global_max_requeues = config.global_max_requeues(total)
 
-          requeued = eval_script(
+          requeued = config.max_requeues > 0 && global_max_requeues > 0 && eval_script(
             :requeue,
             keys: [key('processed'), key('requeues-count'), key('queue'), key('running')],
-            argv: [config.max_requeues, config.global_max_requeues(total), test_key, offset],
+            argv: [config.max_requeues, global_max_requeues, test_key, offset],
           ) == 1
 
           @reserved_test = test_key unless requeued

--- a/ruby/test/fixtures/spec/dummy_spec.rb
+++ b/ruby/test/fixtures/spec/dummy_spec.rb
@@ -3,8 +3,13 @@ RSpec.describe Object do
     expect(1 + 1).to be == 2
   end
 
-  it "doesn't work" do
-    expect(1 + 1).to be == 42
+  it "doesn't work on first try" do
+    if defined?($failing_test_called) && $failing_test_called
+      expect(1 + 1).to be == 2
+    else
+      $failing_test_called = true
+      expect(1 + 1).to be == 42
+    end
   end
 
   describe 'some sublclass' do

--- a/ruby/test/integration/rspec_redis_test.rb
+++ b/ruby/test/integration/rspec_redis_test.rb
@@ -21,8 +21,8 @@ module Integration
           '--build', '1',
           '--worker', '1',
           '--timeout', '1',
-          # '--max-requeues', '1',
-          # '--requeue-tolerance', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
           chdir: 'test/fixtures/',
         )
       end
@@ -31,28 +31,94 @@ module Integration
       expected_output = strip_heredoc <<-EOS
 
         Randomized with seed 123
+        ..*.
+
+        Pending: (Failures listed here are expected and do not affect your suite's status)
+
+          1) Object doesn't work on first try
+             # The example failed, but another attempt will be done to rule out flakiness
+             # ./spec/dummy_spec.rb:6
+
+        Finished in X.XXXXX seconds (files took X.XXXXX seconds to load)
+        4 examples, 0 failures, 1 pending
+
+        Randomized with seed 123
+
+      EOS
+
+      assert_equal expected_output, normalize(out)
+    end
+
+    def test_report
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1', 'BUILDKITE_COMMIT' => 'aaaaaaaaaaaaa' },
+          @exe,
+          '--queue', @redis_url,
+          '--seed', '123',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '0',
+          '--requeue-tolerance', '0',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      assert_empty err
+      expected_output = strip_heredoc <<-EOS
+        
+        Randomized with seed 123
         ..F
 
         Failures:
 
-          1) Object doesn't work
+          1) Object doesn't work on first try
              Failure/Error: expect(1 + 1).to be == 42
 
                expected: == 42
                     got:    2
-             # ./spec/dummy_spec.rb:7:in `block (2 levels) in <top (required)>'
+             # ./spec/dummy_spec.rb:11:in `block (2 levels) in <top (required)>'
 
         Finished in X.XXXXX seconds (files took X.XXXXX seconds to load)
         3 examples, 1 failure
 
         Failed examples:
 
-        rspec ./spec/dummy_spec.rb:6 # Object doesn't work
+        rspec ./spec/dummy_spec.rb:6 # Object doesn't work on first try
 
         Randomized with seed 123
 
       EOS
 
+      assert_equal expected_output, normalize(out)
+
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1', 'BUILDKITE_COMMIT' => 'aaaaaaaaaaaaa' },
+          @exe,
+          '--queue', @redis_url,
+          '--build', '1',
+          '--report',
+          '--timeout', '5',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      assert_empty err
+      expected_output = strip_heredoc <<-EOS
+        --- Waiting for workers to complete
+        +++ 1 error found
+
+          Object doesn't work on first try
+          Failure/Error: expect(1 + 1).to be == 42
+
+            expected: == 42
+                 got:    2
+          # ./spec/dummy_spec.rb:11:in `block (2 levels) in <top (required)>'
+
+        rspec ./spec/dummy_spec.rb:6 # Object doesn't work on first try
+      EOS
 
       assert_equal expected_output, normalize(out)
     end


### PR DESCRIPTION
The monkey patch is particularly tricky because RSpec internals don't expect a single `Example` to be ran twice. The `Example` instances are mutated to keep track of of the run result and then stored in various arrays for later printing the summary.

For example if you skip an example, its `execution_result.status` is set to `:pending` and the example instance is stored in `Reporter#pending_examples`. So if you reset the example instance to be able to run it again, it will stay in the `pending_examples` array and cause all sorts of trouble because it's state will be invalid for most reporters.

To work around this, when we requeue an example, we:
  - clone it 
  - reset the original example instance, and remove it from the reporter
  - Mark the clone as skipped, and add it to the reporter.


I tried to add a lot of comments to make the review easier for people not familiar with RSpec internal, but let me know if there is something you don't understand, as it might mean a comment is missing.

NB: There is a couple TODO left, mostly around making the output nicer, I'd rather handle them in a followup.