### PR TITLE
Shopify's internal dev tool now requires a railgun.yml in addition to the dev.yml

### DIFF
--- a/ruby/railgun.yml
+++ b/ruby/railgun.yml
@@ -2,10 +2,12 @@
 # If you are an external contributor you don't have to bother with it.
 name: ci-queue
 
-up:
-- ruby: 2.1.6
-- bundler
-- railgun
-
-commands:
-  test: REDIS_HOST=ci-queue.railgun bundle exec rake test
+vm:
+  image: /opt/dev/misc/railgun-images/default
+  ip_address: 192.168.64.245
+  memory: 1G
+  cores: 2
+volumes:
+  root: 512M
+services:
+   - redis


### PR DESCRIPTION
I had to do this manually, which is odd, but dev now works properly again.