### PR TITLE
Fix JUnitReporter to respect the spec

### DIFF
--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -24,7 +24,7 @@ module Minitest
 
         xml = Builder::XmlMarkup.new(indent: 2)
         xml.instruct!
-        xml.test_suites do
+        xml.testsuites do
           suites.each do |suite, tests|
             add_tests_to(xml, suite, tests)
           end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -123,7 +123,7 @@ module Integration
 
       assert_equal strip_heredoc(<<-END), normalize_xml(File.read(@junit_path))
        <?xml version="1.0" encoding="UTF-8"?>
-       <test_suites>
+       <testsuites>
          <testsuite name="ATest" filepath="test/dummy_test.rb" skipped="5" failures="1" errors="0" tests="6" assertions="5" time="X.XX">
            <testcase name="test_foo" lineno="4" classname="ATest" assertions="0" time="X.XX" flaky_test="false">
            <skipped type="test_foo"/>
@@ -171,7 +171,7 @@ module Integration
            </error>
            </testcase>
          </testsuite>
-       </test_suites>
+       </testsuites>
       END
     end
 


### PR DESCRIPTION
Somehow we messed that element name up when we moved the code in `ci-queue`.

I checked the spec, it's indeed `testsuites` and not `test_suites`: https://github.com/windyroad/JUnit-Schema/blob/49e95a79cc0bfba7961aaf779710a43a4d3f96bd/JUnit.xsd#L18