### PR TITLE
Check if queue is exhausted before loading tests

### DIFF
--- a/ruby/lib/ci/queue/common.rb
+++ b/ruby/lib/ci/queue/common.rb
@@ -3,6 +3,9 @@ module CI
     module Common
       attr_reader :config
 
+      # to override in classes including this module
+      CONNECTION_ERRORS = [].freeze
+
       def flaky?(test)
         @config.flaky?(test)
       end
@@ -13,6 +16,12 @@ module CI
 
       def report_success!
         config.circuit_breaker.report_success!
+      end
+
+      def rescue_connection_errors(handler = ->(err) { nil })
+        yield
+      rescue *self::class::CONNECTION_ERRORS => err
+        handler.call(err)
       end
     end
   end

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -4,6 +4,11 @@ module CI
       class Base
         include Common
 
+        CONNECTION_ERRORS = [
+          ::Redis::BaseConnectionError,
+          ::SocketError, # https://github.com/redis/redis-rb/pull/631
+        ].freeze
+
         def initialize(redis_url, config)
           @redis_url = redis_url
           @redis = ::Redis.new(url: redis_url)

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -3,11 +3,6 @@ require 'ci/queue/static'
 module CI
   module Queue
     module Redis
-      CONNECTION_ERRORS = [
-        ::Redis::BaseConnectionError,
-        ::SocketError, # https://github.com/redis/redis-rb/pull/631
-      ].freeze
-
       ReservationError = Class.new(StandardError)
 
       class << self

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -57,8 +57,11 @@ module Minitest
 
         trap('TERM') { Minitest.queue.shutdown! }
         trap('INT') { Minitest.queue.shutdown! }
-        load_tests
-        populate_queue
+
+        unless queue.rescue_connection_errors { queue.exhausted? }
+          load_tests
+          populate_queue
+        end
         # Let minitest's at_exit hook trigger
       end
 


### PR DESCRIPTION
## Problem

If we run tests from multiple namespaces using chained `minitest-queue` commands, e.g.

```
minitest-queue --namespace suite-a run && minitest-queue --namespace suite-b run
```

then it will be more likely that the queue might be consumed at the start of the `minitest-queue` command.  However, right now it would still load the tests and try to populate the queue before detecting that the queue has already been exhausted.

## Solution

Avoid doing `load_tests` or `populate_queue` in the `run_command` method if the queue has already been exhausted.

There is a test that makes sure an exception isn't raised if redis is down, so I've added a `rescue_connection_errors` method on the queue to abstractly handle these connection exceptions.