### PR TITLE
Fix double counting of requeued tests in redis retry progress

### DIFF
--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -50,7 +50,6 @@ module CI
       def poll
         while !config.circuit_breaker.open? && test = @queue.shift
           yield index.fetch(test)
-          @progress += 1
         end
       end
 
@@ -59,6 +58,7 @@ module CI
       end
 
       def acknowledge(test)
+        @progress += 1
         true
       end
 

--- a/ruby/test/support/shared_queue_assertions.rb
+++ b/ruby/test/support/shared_queue_assertions.rb
@@ -63,6 +63,7 @@ module SharedQueueAssertions
 
   def test_requeue
     assert_equal [shuffled_test_list.first, *shuffled_test_list], poll(@queue, false)
+    assert_equal @queue.total, @queue.progress
   end
 
   def test_acknowledge


### PR DESCRIPTION
## Problem

When using ci-queue with redis on a retry, the progress was going over the total, which would result in an ProgressBar::InvalidProgressError exception when using the progress with the ruby-progressbar gem.

## Solution

Increment the progress on acknowledge so that it isn't also incremented when the test is requeued.

The added test assertion for the progress at the end of the test_requeue test will fail without the included fix.