### PR TITLE
Use shipit to release to rubygems

### DIFF
--- a/shipit.rubygems.yml
+++ b/shipit.rubygems.yml
@@ -1,0 +1,2 @@
+machine:
+  directory: ruby/


### PR DESCRIPTION
## Problem

By default shipit would look at the top-level of the repository to try to discover how to deploy the project, but the ci-queue repo has separate the ruby gems code into a `ruby` subdirectory.

## Solution

Add a shipit.yml file that uses [machine.directory](https://github.com/shopify/shipit-engine#directory) to try to deploy from the ruby subdirectory.