### PR TITLE
rspec-queue: prevent early exit from exiting with a failure status

### DIFF
--- a/ruby/dev.yml
+++ b/ruby/dev.yml
@@ -3,7 +3,7 @@
 name: ci-queue
 
 up:
-- ruby: 2.1.6
+- ruby: 2.3.7
 - bundler
 - railgun
 

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -259,7 +259,6 @@ module RSpec
       end
 
       def run(reporter)
-        return if RSpec.world.wants_to_quit
         instance = example_group.new(example.inspect_output)
         example_group.set_ivars(instance, example_group.before_context_ivars)
         example.run(instance, reporter)
@@ -386,6 +385,7 @@ module RSpec
             break if @world.wants_to_quit
             queue.poll do |example|
               success &= example.run(QueueReporter.new(reporter, queue, example))
+              break if @world.wants_to_quit
             end
           end
         end

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -261,7 +261,8 @@ module RSpec
       def run(reporter)
         instance = example_group.new(example.inspect_output)
         example_group.set_ivars(instance, example_group.before_context_ivars)
-        example.run(instance, reporter)
+        result = example.run(instance, reporter)
+        result.nil? ? true : result
       end
     end
 


### PR DESCRIPTION
Some jobs are exiting with status `1` even though all the examples they ran succeeded, and the report job succeed.

I suspect it's the `return if RSpec.world.wants_to_quit` which is causing this by returning `nil` from `SingleExample#run`.