### PR TITLE
Add support for default Heroku CI ENV vars

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -23,6 +23,7 @@ Or install it yourself as:
   - Buildkite
   - CircleCI
   - Travis
+  - Heroku CI
 
 If you are using another CI system, please refer to the command usage message.
 

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -8,9 +8,9 @@ module CI
       class << self
         def from_env(env)
           new(
-            build_id: env['CIRCLE_BUILD_URL'] || env['BUILDKITE_BUILD_ID'] || env['TRAVIS_BUILD_ID'],
-            worker_id: env['CIRCLE_NODE_INDEX'] || env['BUILDKITE_PARALLEL_JOB'],
-            seed: env['CIRCLE_SHA1'] || env['BUILDKITE_COMMIT'] || env['TRAVIS_COMMIT'],
+            build_id: env['CIRCLE_BUILD_URL'] || env['BUILDKITE_BUILD_ID'] || env['TRAVIS_BUILD_ID'] || env['HEROKU_TEST_RUN_ID'],
+            worker_id: env['CIRCLE_NODE_INDEX'] || env['BUILDKITE_PARALLEL_JOB'] || env['CI_NODE_INDEX'],
+            seed: env['CIRCLE_SHA1'] || env['BUILDKITE_COMMIT'] || env['TRAVIS_COMMIT'] || env['HEROKU_TEST_RUN_COMMIT_VERSION'],
             flaky_tests: load_flaky_tests(env['CI_QUEUE_FLAKY_TESTS']),
             statsd_endpoint: env['CI_QUEUE_STATSD_ADDR'],
           )

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -198,7 +198,7 @@ module Minitest
           help = split_heredoc(<<-EOS)
             Unique identifier for the workload. All workers working on the same suite of tests must have the same build identifier.
             If the build is tried again, or another revision is built, this value must be different.
-            It's automatically inferred on Buildkite, CircleCI and Travis.
+            It's automatically inferred on Buildkite, CircleCI, Heroku CI, and Travis.
           EOS
           opts.separator ""
           opts.on('--build BUILD_ID', *help) do |build_id|
@@ -239,7 +239,7 @@ module Minitest
 
           help = split_heredoc(<<-EOS)
             Sepcify a seed used to shuffle the test suite.
-            On Buildkite, CircleCI and Travis, the commit revision will be used by default.
+            On Buildkite, CircleCI, Heroku CI, and Travis, the commit revision will be used by default.
           EOS
           opts.separator ""
           opts.on('--seed SEED', *help) do |seed|
@@ -249,7 +249,7 @@ module Minitest
           help = split_heredoc(<<-EOS)
             A unique identifier for this worker, It must be consistent to allow retries.
             If not specified, retries won't be available.
-            It's automatically inferred on Buildkite and CircleCI.
+            It's automatically inferred on Buildkite, Heroku CI, and CircleCI.
           EOS
           opts.separator ""
           opts.on('--worker WORKER_ID', *help) do |worker_id|

--- a/ruby/test/ci/queue/configuration_test.rb
+++ b/ruby/test/ci/queue/configuration_test.rb
@@ -13,6 +13,17 @@ module CI::Queue
       assert_equal 'faa647bbb8168a77cf338e7488c3f8445c3e6554', config.seed
     end
 
+    def test_heroku_ci_defaults
+      config = Configuration.from_env(
+        'HEROKU_TEST_RUN_ID' => 'YouAreAnAmazingPersonAndIBelieveYouCanDoIt',
+        'CI_NODE_INDEX' => '12',
+        'HEROKU_TEST_RUN_COMMIT_VERSION' => 'zaa647bbb8168a77cf338e7488c3f8445c3e6554',
+      )
+      assert_equal 'YouAreAnAmazingPersonAndIBelieveYouCanDoIt', config.build_id
+      assert_equal '12', config.worker_id
+      assert_equal 'zaa647bbb8168a77cf338e7488c3f8445c3e6554', config.seed
+    end
+
     def test_buildkite_defaults
       config = Configuration.from_env(
         'BUILDKITE_BUILD_ID' => '9e08ef3c-d6e6-4a86-91dd-577ce5205b8e',


### PR DESCRIPTION
Details on env vars are found at:

- https://devcenter.heroku.com/articles/heroku-ci#environment-variables-env-key
- https://devcenter.heroku.com/articles/heroku-ci-parallel-test-runs#parallelizing-your-tests

Splitting up #81 into two different PRs for separate discussion.
