### PR TITLE
Default to REDIS_URL if present fallback localhost

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -188,7 +188,8 @@ module Minitest
 
           help = split_heredoc(<<-EOS)
             URL of the queue, e.g. redis://example.com.
-            Defaults to $CI_QUEUE_URL if set.
+            Will use $CI_QUEUE_URL or $REDIS_URL if set.
+            Defaults to redis://localhost:6379.
           EOS
           opts.separator ""
           opts.on('--queue URL', *help) do |url|
@@ -314,7 +315,7 @@ module Minitest
       end
 
       def queue_url
-        @queue_url || ENV['CI_QUEUE_URL']
+        @queue_url || ENV['CI_QUEUE_URL'] || ENV['REDIS_URL'] || "redis://localhost:6379"
       end
 
       def invalid_usage!(message)

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -188,8 +188,7 @@ module Minitest
 
           help = split_heredoc(<<-EOS)
             URL of the queue, e.g. redis://example.com.
-            Will use $CI_QUEUE_URL or $REDIS_URL if set.
-            Defaults to redis://localhost:6379.
+            Defaults to $CI_QUEUE_URL or $REDIS_URL if set.
           EOS
           opts.separator ""
           opts.on('--queue URL', *help) do |url|
@@ -315,7 +314,7 @@ module Minitest
       end
 
       def queue_url
-        @queue_url || ENV['CI_QUEUE_URL'] || ENV['REDIS_URL'] || "redis://localhost:6379"
+        @queue_url || ENV['CI_QUEUE_URL'] || ENV['REDIS_URL']
       end
 
       def invalid_usage!(message)

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -15,7 +15,7 @@ module RSpec
       private
 
       def queue_url
-        configuration.queue_url || ENV['CI_QUEUE_URL']
+        configuration.queue_url || ENV['CI_QUEUE_URL'] || ENV['REDIS_URL'] || "redis://localhost:6379"
       end
 
       def retrying
@@ -71,7 +71,8 @@ module RSpec
 
         help = split_heredoc(<<-EOS)
           URL of the queue, e.g. redis://example.com.
-          Defaults to $CI_QUEUE_URL if set.
+          Will use $CI_QUEUE_URL or $REDIS_URL if set.
+          Defaults to redis://localhost:6379.
         EOS
         parser.separator ""
         parser.on('--queue URL', *help) do |url|

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -15,7 +15,7 @@ module RSpec
       private
 
       def queue_url
-        configuration.queue_url || ENV['CI_QUEUE_URL'] || ENV['REDIS_URL'] || "redis://localhost:6379"
+        configuration.queue_url || ENV['CI_QUEUE_URL'] || ENV['REDIS_URL']
       end
 
       def retrying
@@ -71,8 +71,7 @@ module RSpec
 
         help = split_heredoc(<<-EOS)
           URL of the queue, e.g. redis://example.com.
-          Will use $CI_QUEUE_URL or $REDIS_URL if set.
-          Defaults to redis://localhost:6379.
+          Defaults to $CI_QUEUE_URL or $REDIS_URL if set.
         EOS
         parser.separator ""
         parser.on('--queue URL', *help) do |url|
@@ -320,7 +319,7 @@ module RSpec
         @options.options.delete(:requires) # Prevent loading of spec_helper so the app doesn't need to boot
         @options.configure(@configuration)
 
-        invalid_usage!('Missing --queue parameter') unless queue_url
+        invalid_usage!('Missing --queue parameter. For example: `--queue redis://localhost:6379`') unless queue_url
         invalid_usage!('Missing --build parameter') unless RSpec::Queue.config.build_id
       end
     end
@@ -362,7 +361,7 @@ module RSpec
 
       def setup(err, out)
         super
-        invalid_usage!('Missing --queue parameter') unless queue_url
+        invalid_usage!('Missing --queue parameter. For example: `--queue redis://localhost:6379`') unless queue_url
         invalid_usage!('Missing --build parameter') unless RSpec::Queue.config.build_id
         invalid_usage!('Missing --worker parameter') unless RSpec::Queue.config.worker_id
       end


### PR DESCRIPTION
Similar to `DATABASE_URL` the `REDIS_URL` is a semi-standard at this point, it’s also what you get by default if you add a Redis provider to Heroku. 

When no env var is set and no option given we should default to the default local installation port of redis.

Moved only the REDIS_URL stuff from #81 to this PR.
