### PR TITLE
Only run failed tests on retry

### DIFF
--- a/ruby/lib/ci/queue/redis/build_record.rb
+++ b/ruby/lib/ci/queue/redis/build_record.rb
@@ -16,6 +16,10 @@ module CI
           @queue.exhausted?
         end
 
+        def failed_tests
+          redis.hkeys(key('error-reports'))
+        end
+
         def record_error(id, payload, stats: nil)
           redis.pipelined do
             redis.hset(

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -55,7 +55,11 @@ module CI
         end
 
         def retry_queue
-          log = redis.lrange(key('worker', worker_id, 'queue'), 0, -1).reverse.uniq
+          failures = build.failed_tests.to_set
+          log = redis.lrange(key('worker', worker_id, 'queue'), 0, -1)
+          log.select! { |id| failures.include?(id) }
+          log.uniq!
+          log.reverse!
           Retry.new(log, config, redis: redis)
         end
 

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -37,7 +37,10 @@ module Minitest
       end
 
       def retry_command
-        self.queue = queue.retry_queue
+        retry_queue = queue.retry_queue
+        unless retry_queue.exhausted?
+          self.queue = retry_queue
+        end
         run_command
       end
 
@@ -58,7 +61,9 @@ module Minitest
         trap('TERM') { Minitest.queue.shutdown! }
         trap('INT') { Minitest.queue.shutdown! }
 
-        unless queue.rescue_connection_errors { queue.exhausted? }
+        if queue.rescue_connection_errors { queue.exhausted? }
+          puts green("All tests were ran already")
+        else
           load_tests
           populate_queue
         end

--- a/ruby/test/fixtures/test/passing_test.rb
+++ b/ruby/test/fixtures/test/passing_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class PassingTest < Minitest::Test
+  100.times do |i|
+    define_method("test_passing_#{i}") do
+      assert true
+    end
+  end
+end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -99,7 +99,47 @@ module Integration
       end
       assert_empty err
       output = normalize(out.lines.last.strip)
-      assert_equal 'Ran 11 tests, 8 assertions, 2 failures, 1 errors, 1 skips, 4 requeues in X.XXs', output
+      assert_equal 'Ran 6 tests, 4 assertions, 2 failures, 1 errors, 0 skips, 3 requeues in X.XXs', output
+    end
+
+    def test_retry_success
+      out, err = capture_subprocess_io do
+        system(
+          @exe, 'run',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest',
+          'test/passing_test.rb',
+          chdir: 'test/fixtures/',
+        )
+      end
+      assert_empty err
+      output = normalize(out.lines.last.strip)
+      assert_equal 'Ran 100 tests, 100 assertions, 0 failures, 0 errors, 0 skips, 0 requeues in X.XXs', output
+
+      out, err = capture_subprocess_io do
+        system(
+          @exe, 'retry',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest',
+          'test/passing_test.rb',
+          chdir: 'test/fixtures/',
+        )
+      end
+      assert_empty err
+      output = normalize(out.lines.last.strip)
+      assert_equal 'All tests were ran already', output
     end
 
     def test_down_redis

--- a/ruby/test/integration/rspec_redis_test.rb
+++ b/ruby/test/integration/rspec_redis_test.rb
@@ -119,22 +119,10 @@ module Integration
       expected_output = strip_heredoc <<-EOS
 
         Randomized with seed 123
-        ..*.
 
-        Pending: (Failures listed here are expected and do not affect your suite's status)
-
-          1) Object doesn't work on first try
-             # The example failed, but another attempt will be done to rule out flakiness
-
-             Failure/Error: expect(1 + 1).to be == 42
-
-               expected: == 42
-                    got:    2
-             # ./spec/dummy_spec.rb:11:in `block (2 levels) in <top (required)>'
-             # ./spec/dummy_spec.rb:6
 
         Finished in X.XXXXX seconds (files took X.XXXXX seconds to load)
-        4 examples, 0 failures, 1 pending
+        0 examples, 0 failures
 
         Randomized with seed 123
 


### PR DESCRIPTION
### Previous retry behavior

The worker would simply run the exact same list of tests it ran before failing / crashing

### New retry behavior

The worker only run the failed test it ran previously. 

If no test failed, then it simply goes back to poll the general queue.

If the general queue is exhausted as well, it early exit.

### Rationale

The previous behavior was implemented as is for consistency reasons, if a test was impacted by a leak we wanted the test order to be the same so that it's replicable.

But really retries happen for two reasons:

  - The developer manually retry the job because it failed due to a flaky or leaky test. They actually want the leak not to happen again, so we might as well only retry failures so that it's both faster and less likely to be impacted by the leak.

  - The job was retried automatically because we detected an infrastructure failure, in this case re-running successful tests is wasteful, we might as go back to poll the test queue.

