### PR TITLE
Reset minitest stats on retry

### DIFF
--- a/ruby/lib/ci/queue/build_record.rb
+++ b/ruby/lib/ci/queue/build_record.rb
@@ -31,6 +31,10 @@ module CI
         stat_names.zip(stats.values_at(*stat_names).map(&:to_f))
       end
 
+      def reset_stats(stat_names)
+        stat_names.each { |s| stats.delete(s) }
+      end
+
       private
 
       attr_reader :stats

--- a/ruby/lib/ci/queue/redis/build_record.rb
+++ b/ruby/lib/ci/queue/redis/build_record.rb
@@ -51,6 +51,14 @@ module CI
           stat_names.zip(counts.map { |values| values.map(&:to_f).inject(:+).to_f }).to_h
         end
 
+        def reset_stats(stat_names)
+          redis.pipelined do
+            stat_names.each do |stat_name|
+              redis.hdel(key(stat_name), config.worker_id)
+            end
+          end
+        end
+
         private
 
         attr_reader :config, :redis

--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -25,7 +25,7 @@ module Minitest
       end
 
       def success?
-        errors == 0 && failures == 0
+        build.error_reports.empty?
       end
 
       def record(*)

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -37,6 +37,7 @@ module Minitest
       end
 
       def retry_command
+        reset_counters
         retry_queue = queue.retry_queue
         unless retry_queue.exhausted?
           self.queue = retry_queue
@@ -154,6 +155,10 @@ module Minitest
 
         _, status = Process.wait2(child_pid)
         return status.success?
+      end
+
+      def reset_counters
+        queue.build.reset_stats(BuildStatusRecorder::COUNTERS)
       end
 
       def populate_queue

--- a/ruby/test/fixtures/test/flaky_test.rb
+++ b/ruby/test/fixtures/test/flaky_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class FlakyTest < Minitest::Test
+  def test_dummy
+    assert true
+  end
+
+  def test_flaky
+    assert_equal '1', ENV['FLAKY_TEST_PASS']
+  end
+end


### PR DESCRIPTION
In some circumstances, after retrying failed workers a build could end up with the report step complaining about errors, but no error reports not failed workers.

What would happen is that a worker would have failed, but it's failing test would have been retried by another worker. So all test ultimately pass.

However when retrying the first worker, it sees the queue is all worked off and simply bail out with a success.

The problem is that the report job was looking at `failures` and `errors` stats, which would have been left pristine by the retried worker.

The solution here is to look at the `error-reports` hash instead, which has the benefit of being updated in an idempotent way, so is a much better source of truth.

Additionally, workers reset their minitest stats on retry, this will cause less consistent stats, but make it much less likely to have a report steps succeeded while displaying a number of `errors/failures` which will inevitably alert users.