### PR TITLE
Flush `OrderReporter` before running test

### DIFF
--- a/ruby/lib/minitest/queue/order_reporter.rb
+++ b/ruby/lib/minitest/queue/order_reporter.rb
@@ -14,6 +14,7 @@ class Minitest::Queue::OrderReporter < Minitest::Reporters::BaseReporter
   def before_test(test)
     super
     @file.puts("#{test.class.name}##{test.name}")
+    @file.flush
   end
 
   def report


### PR DESCRIPTION
Small change so we can always trust that, while running, the value in the logs is up to date.