### PR TITLE
nextitem + no shuffling

### DIFF
--- a/python/ciqueue/distributed.py
+++ b/python/ciqueue/distributed.py
@@ -70,7 +70,7 @@ class Worker(Base):
 
     def __iter__(self):
         def poll():
-            while not self.shutdown_required and len(self):  # pylint: disable=len-as-condition
+            while not self.shutdown_required and self.redis.llen(self.key('queue')):
                 test = self._reserve()
                 if test:
                     yield test.decode()

--- a/python/ciqueue/pytest.py
+++ b/python/ciqueue/pytest.py
@@ -5,6 +5,7 @@ py.test -p ciqueue.pytest --queue redis://<host>:6379?worker=<worker_id>&build=<
 """
 from __future__ import absolute_import
 from __future__ import print_function
+from collections import OrderedDict
 import zlib
 from ciqueue._pytest import test_queue
 from ciqueue._pytest import outcomes
@@ -25,7 +26,7 @@ def pytest_addoption(parser):
 class ItemIndex(object):
 
     def __init__(self, items):
-        self.index = dict((test_queue.key_item(i), i) for i in items)
+        self.index = OrderedDict((test_queue.key_item(i), i) for i in items)
 
     def __len__(self):
         return len(self.index)


### PR DESCRIPTION
Here's two changes we've been running in prod for a while. I was lazy and opened them together since I wasn't sure if the python plugin was active anyway.

Nearly everything is to support pytest's `nextitem`: passing it can improve performance significantly by avoiding unnecessary fixture teardown/setup (xdist does the same thing, and has some notes on it [here](https://github.com/pytest-dev/pytest-xdist/blob/master/OVERVIEW.md)). Essentially, the workers now try to pull two tests instead of one, and finish once the queue is empty (to avoid deadlocks when eg there is one test left and multiple workers with only one buffered locally).

I also tweaked ItemIndex to not implicitly order tests by their hash value in python 2.