### PR TITLE
Deprecate the retry subcommand and make the behavior automatic

### DIFF
--- a/ruby/lib/ci/queue/common.rb
+++ b/ruby/lib/ci/queue/common.rb
@@ -6,6 +6,10 @@ module CI
       # to override in classes including this module
       CONNECTION_ERRORS = [].freeze
 
+      def retrying?
+        false
+      end
+
       def flaky?(test)
         @config.flaky?(test)
       end

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -54,6 +54,12 @@ module CI
         rescue *CONNECTION_ERRORS
         end
 
+        def retrying?
+          redis.exists(key('worker', worker_id, 'queue'))
+        rescue *CONNECTION_ERRORS
+          false
+        end
+
         def retry_queue
           failures = build.failed_tests.to_set
           log = redis.lrange(key('worker', worker_id, 'queue'), 0, -1)

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -37,15 +37,22 @@ module Minitest
       end
 
       def retry_command
-        reset_counters
-        retry_queue = queue.retry_queue
-        unless retry_queue.exhausted?
-          self.queue = retry_queue
-        end
-        run_command
+        STDERR.puts "Warning: the retry subcommand is deprecated."
+        run_command # aliased for backward compatibility purpose
       end
 
       def run_command
+        if queue.retrying?
+          reset_counters
+          retry_queue = queue.retry_queue
+          if retry_queue.exhausted?
+            puts "The retry queue does not contain any failure, we'll process the main queue instead."
+          else
+            puts "Retrying failed tests."
+            self.queue = retry_queue
+          end
+        end
+
         set_load_path
         Minitest.queue = queue
         reporters = [

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -84,7 +84,7 @@ module Integration
 
       out, err = capture_subprocess_io do
         system(
-          @exe, 'retry',
+          @exe, 'run',
           '--queue', @redis_url,
           '--seed', 'foobar',
           '--build', '1',
@@ -124,7 +124,7 @@ module Integration
 
       out, err = capture_subprocess_io do
         system(
-          @exe, 'retry',
+          @exe, 'run',
           '--queue', @redis_url,
           '--seed', 'foobar',
           '--build', '1',
@@ -200,7 +200,7 @@ module Integration
       # Retry first worker, bailing out
       out, err = capture_subprocess_io do
         system(
-          @exe, 'retry',
+          @exe, 'run',
           '--queue', @redis_url,
           '--seed', 'foobar',
           '--build', '1',

--- a/ruby/test/integration/rspec_redis_test.rb
+++ b/ruby/test/integration/rspec_redis_test.rb
@@ -104,7 +104,6 @@ module Integration
           { 'BUILDKITE' => '1', 'BUILDKITE_COMMIT' => 'aaaaaaaaaaaaa' },
           @exe,
           '--queue', @redis_url,
-          '--retry',
           '--seed', '123',
           '--build', '1',
           '--worker', '1',
@@ -117,6 +116,7 @@ module Integration
 
       assert_empty err
       expected_output = strip_heredoc <<-EOS
+        Found 0 tests to retry, processing the main queue.
 
         Randomized with seed 123
 


### PR DESCRIPTION
The `retry` subcommand (or `--retry` flag for rspec) makes it hard to integrate on CI, and we realized many of our pipeline didn't integrate that part.

This caused and imperfect behavior that surprises people.

Since not all CI systems expose jobs retry as an env var, I chose to inspect Redis to detect wether we are retrying or not.