### PR TITLE
Add support for Semaphore 2

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -24,6 +24,7 @@ Or install it yourself as:
   - CircleCI
   - Travis
   - Heroku CI
+  - Semaphore 2
 
 If you are using another CI system, please refer to the command usage message.
 

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -8,9 +8,9 @@ module CI
       class << self
         def from_env(env)
           new(
-            build_id: env['CIRCLE_BUILD_URL'] || env['BUILDKITE_BUILD_ID'] || env['TRAVIS_BUILD_ID'] || env['HEROKU_TEST_RUN_ID'],
-            worker_id: env['CIRCLE_NODE_INDEX'] || env['BUILDKITE_PARALLEL_JOB'] || env['CI_NODE_INDEX'],
-            seed: env['CIRCLE_SHA1'] || env['BUILDKITE_COMMIT'] || env['TRAVIS_COMMIT'] || env['HEROKU_TEST_RUN_COMMIT_VERSION'],
+            build_id: env['CIRCLE_BUILD_URL'] || env['BUILDKITE_BUILD_ID'] || env['TRAVIS_BUILD_ID'] || env['HEROKU_TEST_RUN_ID'] || env['SEMAPHORE_PIPELINE_ID'],
+            worker_id: env['CIRCLE_NODE_INDEX'] || env['BUILDKITE_PARALLEL_JOB'] || env['CI_NODE_INDEX'] || env['SEMAPHORE_JOB_ID'],
+            seed: env['CIRCLE_SHA1'] || env['BUILDKITE_COMMIT'] || env['TRAVIS_COMMIT'] || env['HEROKU_TEST_RUN_COMMIT_VERSION'] || env['SEMAPHORE_GIT_SHA'],
             flaky_tests: load_flaky_tests(env['CI_QUEUE_FLAKY_TESTS']),
             statsd_endpoint: env['CI_QUEUE_STATSD_ADDR'],
           )

--- a/ruby/test/ci/queue/configuration_test.rb
+++ b/ruby/test/ci/queue/configuration_test.rb
@@ -44,6 +44,19 @@ module CI::Queue
       assert_equal 'faa647bbb8168a77cf338e7488c3f8445c3e6554', config.seed
     end
 
+
+    def test_semaphore2_defaults
+      config = Configuration.from_env(
+        'SEMAPHORE_PIPELINE_ID' => 'a47d9178-a94e-435a-9bbd-a095aee1e41c',
+        'SEMAPHORE_JOB_ID' => '04f953b6-493c-424e-a9a4-e8a0c28f4bc2',
+        'SEMAPHORE_GIT_SHA' => 'faa647bbb8168a77cf338e7488c3f8445c3e6554',
+      )
+
+      assert_equal 'a47d9178-a94e-435a-9bbd-a095aee1e41c', config.build_id
+      assert_equal '04f953b6-493c-424e-a9a4-e8a0c28f4bc2', config.worker_id
+      assert_equal 'faa647bbb8168a77cf338e7488c3f8445c3e6554', config.seed
+    end
+
     def test_namespace
       config = Configuration.new(build_id: '9e08ef3c-d6e6-4a86-91dd-577ce5205b8e')
       assert_equal '9e08ef3c-d6e6-4a86-91dd-577ce5205b8e', config.build_id


### PR DESCRIPTION
Shopify, thank you for publishing the gem!

I'd like to contribute support for Semaphore 2 with the following defaults:

- Build ID - taken from [`SEMAPHORE_PIPELINE_ID`](https://docs.semaphoreci.com/article/12-environment-variables#semaphore_pipeline_id) (but see my note below)
- Worker ID - taken from [`SEMAPHORE_JOB_ID`](https://docs.semaphoreci.com/article/12-environment-variables#semaphore_job_id)
- Seed - based on [`SEMAPHORE_GIT_SHA`](https://docs.semaphoreci.com/article/12-environment-variables#semaphore_git_sha)

Regarding build ID, I wasn't sure whether to chose `SEMAPHORE_PIPELINE_ID` or [`SEMAPHORE_WORKFLOW_ID`](https://docs.semaphoreci.com/article/12-environment-variables#semaphore_workflow_id). According to [the documentation](https://docs.semaphoreci.com/article/62-concepts), a workflow is comprised of several pipelines which are comprised of several blocks.

My thinking is that by scoping `ci-queue` to a pipeline we'll have stronger isolation in cases when two pipelines running in parallel use `ci-queue`. However, I'm not 100% sure on that and would like your feedback here.