### PR TITLE
Remove reset_counters method for rspec

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -47,7 +47,7 @@ setuplib.setup(
         'test': [
             'tox==2.9.1',
             'shopify_python==0.4.1',
-            'pycodestyle == 2.3.0',
+            'pycodestyle == 2.4.0',
         ]
     },
     package_data={'': get_lua_scripts()},

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -377,7 +377,6 @@ module RSpec
             puts "Found 0 tests to retry, processing the main queue."
           else
             puts "Retrying #{retry_queue.size} failed tests."
-            reset_counters
             queue = retry_queue
           end
         end

--- a/ruby/test/fixtures/spec/dummy_spec.rb
+++ b/ruby/test/fixtures/spec/dummy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Object do
   end
 
   it "doesn't work on first try" do
-    if defined?($failing_test_called) && $failing_test_called
+    if defined?($failing_test_called) && $failing_test_called || ENV['RETRIED'] == "1"
       expect(1 + 1).to be == 2
     else
       $failing_test_called = true
@@ -12,7 +12,7 @@ RSpec.describe Object do
     end
   end
 
-  describe 'some sublclass' do
+  describe 'some subclass' do
 
     it "should be ran as well" do
       expect(1 + 1).to be == 2


### PR DESCRIPTION
I bumped `ci-queue` to 0.15.0 for spy, but because it uses rspec I found that the `reset_counters` wasn't in the rspec queue.

EDIT: And is not needed.

I kinda reverse engineered this a bit, but tried to keep it inline with the minitest queue. 

~I'm not sure how to test it either :( I'm not a huge rspec person~ Added test

https://buildkite.com/shopify/spy/builds/10719#39e0272c-08d9-43e9-a75a-afdee9935c23/312-318

Also fixed Python tests