### PR TITLE
Implement test_order logging for RSpec implementation

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -11,4 +11,4 @@ test/fixtures/log/test_order.log
 /spec/reports/
 /tmp/
 /lib/ci/queue/redis/*.lua
-
+test_order.log

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -1,7 +1,9 @@
+require 'fileutils'
 require 'delegate'
 require 'rspec/core'
 require 'ci/queue'
 require 'rspec/queue/build_status_recorder'
+require 'rspec/queue/order_recorder'
 
 module RSpec
   module Queue
@@ -387,6 +389,8 @@ module RSpec
         success = true
         @configuration.reporter.report(examples_count) do |reporter|
           @configuration.add_formatter(BuildStatusRecorder)
+          FileUtils.mkdir_p('log')
+          @configuration.add_formatter(OrderRecorder, open('log/test_order.log', 'w+'))
 
           @configuration.with_suite_hooks do
             break if @world.wants_to_quit

--- a/ruby/lib/rspec/queue/order_recorder.rb
+++ b/ruby/lib/rspec/queue/order_recorder.rb
@@ -1,0 +1,19 @@
+require 'rspec/core/formatters/base_formatter'
+
+module RSpec
+  module Queue
+    class OrderRecorder < ::RSpec::Core::Formatters::BaseFormatter
+      ::RSpec::Core::Formatters.register self, :example_started
+
+      def initialize(*)
+        super
+        output.sync = true
+      end
+
+      def example_started(notification)
+        return if notification.is_a?(RSpec::Core::Notifications::SkippedExampleNotification)
+        output.write("#{notification.example.id}\n")
+      end
+    end
+  end
+end

--- a/ruby/test/integration/rspec_redis_test.rb
+++ b/ruby/test/integration/rspec_redis_test.rb
@@ -9,6 +9,9 @@ module Integration
       @redis = Redis.new(url: @redis_url)
       @redis.flushdb
       @exe = File.expand_path('../../../exe/rspec-queue', __FILE__)
+
+      @order_path = File.expand_path('../../fixtures/log/test_order.log', __FILE__)
+      File.delete(@order_path) if File.exist?(@order_path)
     end
 
     def test_redis_runner
@@ -54,6 +57,16 @@ module Integration
       EOS
 
       assert_equal expected_output, normalize(out)
+
+
+      expected_test_order = [
+        "./spec/dummy_spec.rb[1:1]\n",
+        "./spec/dummy_spec.rb[1:3:1]\n",
+        "./spec/dummy_spec.rb[1:2]\n",
+        "./spec/dummy_spec.rb[1:2]\n",
+      ]
+
+      assert_equal expected_test_order, File.read(@order_path).lines
     end
 
     def test_redis_runner_retry


### PR DESCRIPTION
Fix: https://github.com/Shopify/ci-queue/issues/98

Log test order in a file with the RSpec implementation to be able to replay the sequence with `rspec-queue --queue path/to/test_order.log`.

@schneems 