### PR TITLE
Grind command

### DIFF
--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -9,6 +9,7 @@ require 'ci/queue/common'
 require 'ci/queue/build_record'
 require 'ci/queue/static'
 require 'ci/queue/file'
+require 'ci/queue/grind'
 require 'ci/queue/bisect'
 
 module CI

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -1,7 +1,7 @@
 module CI
   module Queue
     class Configuration
-      attr_accessor :timeout, :build_id, :worker_id, :max_requeues
+      attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count
       attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
       attr_reader :circuit_breaker
 
@@ -26,7 +26,8 @@ module CI
 
       def initialize(
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
-        namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil
+        namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
+        grind_count: nil
       )
         @namespace = namespace
         @timeout = timeout
@@ -37,6 +38,7 @@ module CI
         @seed = seed
         @flaky_tests = flaky_tests
         @statsd_endpoint = statsd_endpoint
+        @grind_count = grind_count
         self.max_consecutive_failures = max_consecutive_failures
       end
 

--- a/ruby/lib/ci/queue/grind.rb
+++ b/ruby/lib/ci/queue/grind.rb
@@ -1,0 +1,22 @@
+require 'ci/queue/static'
+
+module CI
+  module Queue
+    class Grind < Static
+      class << self
+        def from_uri(uri, config)
+          new(uri.path, config)
+        end
+      end
+
+      def initialize(path, config)
+        io = path == '-' ? STDIN : ::File.open(path)
+
+        tests_to_run = io.each_line.map(&:strip).reject(&:empty?)
+        test_grinds = (tests_to_run * config.grind_count).sort
+
+        super(test_grinds, config)
+      end
+    end
+  end
+end

--- a/ruby/lib/ci/queue/redis.rb
+++ b/ruby/lib/ci/queue/redis.rb
@@ -2,8 +2,11 @@ require 'redis'
 require 'ci/queue/redis/build_record'
 require 'ci/queue/redis/base'
 require 'ci/queue/redis/worker'
+require 'ci/queue/redis/grind_record'
+require 'ci/queue/redis/grind'
 require 'ci/queue/redis/retry'
 require 'ci/queue/redis/supervisor'
+require 'ci/queue/redis/grind_supervisor'
 
 module CI
   module Queue

--- a/ruby/lib/ci/queue/redis/grind.rb
+++ b/ruby/lib/ci/queue/redis/grind.rb
@@ -1,0 +1,16 @@
+module CI
+  module Queue
+    module Redis
+      class Grind < Worker
+
+        def build
+          @build ||= GrindRecord.new(self, redis, config)
+        end
+
+        def supervisor
+          GrindSupervisor.new(redis_url, config)
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/ci/queue/redis/grind_record.rb
+++ b/ruby/lib/ci/queue/redis/grind_record.rb
@@ -1,0 +1,65 @@
+module CI
+  module Queue
+    module Redis
+      class GrindRecord
+
+        def initialize(queue, redis, config)
+          @queue = queue
+          @redis = redis
+          @config = config
+        end
+
+        def record_error(payload, stats: nil)
+          redis.pipelined do
+            redis.lpush(
+              key('error-reports'),
+              payload.force_encoding(Encoding::BINARY),
+            )
+            record_stats(stats)
+          end
+          nil
+        end
+
+        def record_success(stats: nil)
+          record_stats(stats)
+        end
+
+        def record_warning(_,_)
+          #do nothing
+        end
+
+        def error_reports
+          redis.lrange(key('error-reports'), 0, -1)
+        end
+
+        def fetch_stats(stat_names)
+          counts = redis.pipelined do
+            stat_names.each { |c| redis.hvals(key(c)) }
+          end
+          stat_names.zip(counts.map { |values| values.map(&:to_f).inject(:+).to_f }).to_h
+        end
+
+        def pop_warnings
+          []
+        end
+
+        alias failed_tests error_reports
+
+        private
+
+        attr_reader :redis, :config
+
+        def key(*args)
+          ['build', config.build_id, *args].join(':')
+        end
+
+        def record_stats(stats)
+          return unless stats
+          stats.each do |stat_name, stat_value|
+            redis.hset(key(stat_name), config.worker_id, stat_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/ci/queue/redis/grind_supervisor.rb
+++ b/ruby/lib/ci/queue/redis/grind_supervisor.rb
@@ -1,0 +1,12 @@
+module CI
+  module Queue
+    module Redis
+      class GrindSupervisor < Supervisor
+
+        def build
+          @build ||= GrindRecord.new(self, redis, config)
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -1,5 +1,4 @@
 require 'minitest'
-gem 'minitest-reporters', '~> 1.1'
 require 'minitest/reporters'
 
 require 'minitest/queue/failure_formatter'
@@ -9,6 +8,8 @@ require 'minitest/queue/build_status_recorder'
 require 'minitest/queue/build_status_reporter'
 require 'minitest/queue/order_reporter'
 require 'minitest/queue/junit_reporter'
+require 'minitest/queue/grind_recorder'
+require 'minitest/queue/grind_reporter'
 
 module Minitest
   class Requeue < Skip
@@ -97,6 +98,7 @@ module Minitest
 
   module Queue
     class SingleExample
+
       def initialize(runnable, method_name)
         @runnable = runnable
         @method_name = method_name

--- a/ruby/lib/minitest/queue/grind_recorder.rb
+++ b/ruby/lib/minitest/queue/grind_recorder.rb
@@ -1,0 +1,67 @@
+module Minitest
+  module Queue
+    class GrindRecorder < Minitest::Reporters::BaseReporter
+
+      attr_accessor :test_count
+
+      def self.counters
+        @counters ||= {
+          'failures' => 0,
+          'errors' => 0,
+          'skips' => 0,
+          'test_count' => 0
+        }
+      end
+
+      class << self
+        attr_accessor :failure_formatter
+      end
+      self.failure_formatter = FailureFormatter
+
+      def initialize(build:, **options)
+        super(options)
+        @build = build
+      end
+
+      def record(test)
+        increment_counter(test)
+        record_test(test)
+      end
+
+      private
+
+      def record_test(test)
+        stats = self.class.counters
+        if (test.failure || test.error?) && !test.skipped?
+          build.record_error(dump(test), stats: stats)
+        else
+          build.record_success(stats: stats)
+        end
+      end
+
+      def increment_counter(test)
+        if test.skipped?
+          self.class.counters['skips'] += 1
+        elsif test.error?
+          self.class.counters['errors'] += 1
+        elsif test.failure
+          self.class.counters['failures'] += 1
+        end
+        self.class.counters['test_count'] += 1
+
+        key = "count##{test.klass}##{test.name}"
+
+        unless self.class.counters.key?(key)
+          self.class.counters[key] = 0
+        end
+        self.class.counters[key] += 1
+      end
+
+      def dump(test)
+        ErrorReport.new(self.class.failure_formatter.new(test).to_h).dump
+      end
+
+      attr_reader :build
+    end
+  end
+end

--- a/ruby/lib/minitest/queue/grind_reporter.rb
+++ b/ruby/lib/minitest/queue/grind_reporter.rb
@@ -1,0 +1,73 @@
+require 'minitest/reporters'
+
+module Minitest
+  module Queue
+    class GrindReporter < Minitest::Reporters::BaseReporter
+      include ::CI::Queue::OutputHelpers
+
+      def initialize(build:, **options)
+        @build = build
+        @success = true
+        super(options)
+      end
+
+      def report
+        puts '+++ Results'
+
+        if flaky_tests.empty?
+          puts green('all tests passed every time, grinding did not uncover any flakiness')
+          return
+        end
+        @success = false
+
+        flaky_tests.each do |name, errors|
+          total_runs = fetch_counts(name)
+          flakiness_percentage = (errors.count / total_runs) * 100
+
+          error_messages = errors.map do |message|
+            message.to_s.lines.map { |l| "\t#{l}"}.join
+          end.to_set.to_a.join("\n\n")
+
+          puts <<~EOS
+            #{red(name)}
+            Runs: #{total_runs.to_i}
+            Failures: #{errors.count}
+            Flakiness Percentage: #{flakiness_percentage.to_i}%
+            Errors:
+            #{error_messages}
+          EOS
+        end
+      end
+
+      def success?
+        @success
+      end
+
+      def flaky_tests
+        @flaky_tests ||= begin
+          flaky_tests = {}
+          build.error_reports.each do |error|
+            err = ErrorReport.load(error)
+            name = err.test_and_module_name
+            flaky_tests[name] ||= []
+            flaky_tests[name] << err
+          end
+          flaky_tests
+        end
+      end
+
+      def record(*)
+        raise NotImplementedError
+      end
+
+      def fetch_counts(test)
+        key = "count##{test}"
+        build.fetch_stats([key])[key]
+      end
+
+      private
+
+      attr_reader :build
+    end
+  end
+end

--- a/ruby/test/fixtures/grind_list.txt
+++ b/ruby/test/fixtures/grind_list.txt
@@ -1,0 +1,2 @@
+ATest#test_flaky_passes
+ATest#test_flaky

--- a/ruby/test/fixtures/grind_list_success.txt
+++ b/ruby/test/fixtures/grind_list_success.txt
@@ -1,0 +1,2 @@
+ATest#test_flaky_passes
+

--- a/ruby/test/fixtures/grind_multiples_list.txt
+++ b/ruby/test/fixtures/grind_multiples_list.txt
@@ -1,0 +1,2 @@
+ATest#test_bar
+ATest#test_flaky

--- a/ruby/test/integration/grind_redis_test.rb
+++ b/ruby/test/integration/grind_redis_test.rb
@@ -1,0 +1,152 @@
+require 'test_helper'
+
+module Integration
+  class GrindRedisTest < Minitest::Test
+    include OutputTestHelpers
+
+    def setup
+      @redis_url = "redis://#{ENV.fetch('REDIS_HOST', 'localhost')}/7"
+      @redis = Redis.new(url: @redis_url)
+      @redis.flushdb
+      @exe = File.expand_path('../../../exe/minitest-queue', __FILE__)
+    end
+
+    def test_grind_command_success
+      system(
+        { 'BUILDKITE' => '1' },
+        @exe, 'grind',
+        '--queue', @redis_url,
+        '--seed', 'foobar',
+        '--build', '1',
+        '--worker', '1',
+        '--timeout', '1',
+        '--grind-count', '10',
+        '--grind-list', 'grind_list_success.txt',
+        '-Itest',
+        'test/dummy_test.rb',
+        chdir: 'test/fixtures/',
+      )
+
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          @exe, 'report_grind',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '5',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      output = normalize(out).strip
+      expected = <<~EOS
+        +++ Results
+        all tests passed every time, grinding did not uncover any flakiness
+      EOS
+      assert_equal expected.strip, output
+      assert_empty err
+    end
+
+    def test_grind_command_runs_tests
+      system(
+        { 'BUILDKITE' => '1' },
+        @exe, 'grind',
+        '--queue', @redis_url,
+        '--seed', 'foobar',
+        '--build', '1',
+        '--worker', '1',
+        '--timeout', '1',
+        '--grind-count', '10',
+        '--grind-list', 'grind_list.txt',
+        '-Itest',
+        'test/dummy_test.rb',
+        chdir: 'test/fixtures/',
+      )
+
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          @exe, 'report_grind',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '5',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      output = normalize(out).strip
+      expected = <<~EOS
+        +++ Results
+        ATest#test_flaky
+        Runs: 10
+        Failures: 1
+        Flakiness Percentage: 10%
+        Errors:
+        \tFAIL ATest#test_flaky
+        \tExpected false to be truthy.
+        \t    test/dummy_test.rb:17:in `test_flaky'
+      EOS
+      assert_empty err
+      assert_equal expected.strip, output
+    end
+
+    def test_can_grind_multiple_things
+      system(
+        { 'BUILDKITE' => '1' },
+        @exe, 'grind',
+        '--grind-list', 'grind_multiples_list.txt',
+        '--queue', @redis_url,
+        '--build', '1',
+        '--worker', '1',
+        '--timeout', '1',
+        '--grind-count', '10',
+        '-Itest',
+        'test/dummy_test.rb',
+        chdir: 'test/fixtures/',
+      )
+
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          @exe, 'report_grind',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '5',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      output = normalize(out).strip
+
+      expected = <<~EOS
+        +++ Results
+        ATest#test_flaky
+        Runs: 10
+        Failures: 1
+        Flakiness Percentage: 10%
+        Errors:
+        \tFAIL ATest#test_flaky
+        \tExpected false to be truthy.
+        \t    test/dummy_test.rb:17:in `test_flaky'
+        \t
+
+        ATest#test_bar
+        Runs: 10
+        Failures: 10
+        Flakiness Percentage: 100%
+        Errors:
+        \tFAIL ATest#test_bar
+        \tExpected false to be truthy.
+        \t    test/dummy_test.rb:9:in `test_bar'
+      EOS
+      assert_equal expected.strip, output
+      assert_empty err
+    end
+  end
+end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -78,6 +78,7 @@ module Integration
           chdir: 'test/fixtures/',
         )
       end
+
       assert_empty err
       output = normalize(out.lines.last.strip)
       assert_equal 'Ran 11 tests, 8 assertions, 2 failures, 1 errors, 1 skips, 4 requeues in X.XXs', output
@@ -97,6 +98,7 @@ module Integration
           chdir: 'test/fixtures/',
         )
       end
+
       assert_empty err
       output = normalize(out.lines.last.strip)
       assert_equal 'Ran 6 tests, 4 assertions, 2 failures, 1 errors, 0 skips, 3 requeues in X.XXs', output
@@ -415,10 +417,6 @@ module Integration
 
     def normalize_xml(output)
       freeze_xml_timing(rewrite_paths(output))
-    end
-
-    def normalize(output)
-      freeze_timing(decolorize_output(output))
     end
   end
 end

--- a/ruby/test/support/output_test_helpers.rb
+++ b/ruby/test/support/output_test_helpers.rb
@@ -30,4 +30,8 @@ module OutputTestHelpers
   def freeze_xml_timing(output)
     output.gsub(/time="[\d\-\.e]+"/, 'time="X.XX"')
   end
+
+  def normalize(output)
+    freeze_timing(decolorize_output(output))
+  end
 end


### PR DESCRIPTION
This is a draft for a grind command, which enables us to check if a test is flaky by running it over and over again. In the current version of ci-queue we are able to run a test multiple times, but we aren't able to summarize it. We require a summary step as it gives us a way to communicate the grinding results in a more understandable way. 

When we try to use the report functionality the previous test runs get overridden by newer ones, which causes the reporting to be wrong. We isolated the problem down to tests not being uniquely identifiable. We solve it by adding a sequential id at the end of every test name.

This solution works, but the changes made to `id` are pretty invasive and will lead to confusion. Do you think there is a better way to solving this problem?

here is an example run of the working grind command and reporter:

https://buildkite.com/shopify/shopify-build-onboarding-testing/builds/727#a9a7823d-09a3-4a84-9e48-0a93afb60ddf

\cc @mcgain 