### PR TITLE
fix max duration setter

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -40,7 +40,7 @@ module CI
         @flaky_tests = flaky_tests
         @statsd_endpoint = statsd_endpoint
         @grind_count = grind_count
-        @max_duration = max_duration
+        self.max_duration = max_duration
         self.max_consecutive_failures = max_consecutive_failures
       end
 


### PR DESCRIPTION
We aren't using the the max_duration flag setter in the configuration initializer. This prevents it to be added to the circuit breakers.

ref #102