### PR TITLE
Use exception class for error, failure and skipped type

### DIFF
--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -57,16 +57,16 @@ module Minitest
 
       def xml_message_for(test)
         xml = XmlMarkup.new(indent: 2, margin: 2)
-        error = test.failure
+        failure = test.failure
 
         if test.skipped? && !test.flaked?
-          xml.skipped(type: test.name)
+          xml.skipped(type: failure.error.class.name)
         elsif test.error?
-          xml.error(type: test.name, message: xml.trunc!(error.message)) do
+          xml.error(type: failure.error.class.name, message: xml.trunc!(failure.message)) do
             xml.text!(message_for(test))
           end
-        elsif test.failure
-          xml.failure(type: test.name, message: xml.trunc!(error.message)) do
+        elsif failure
+          xml.failure(type: failure.error.class.name, message: xml.trunc!(failure.message)) do
             xml.text!(message_for(test))
           end
         end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -280,13 +280,13 @@ module Integration
        <testsuites>
          <testsuite name="ATest" filepath="test/dummy_test.rb" skipped="5" failures="1" errors="0" tests="6" assertions="5" time="X.XX">
            <testcase name="test_foo" lineno="4" classname="ATest" assertions="0" time="X.XX" flaky_test="false">
-           <skipped type="test_foo"/>
+           <skipped type="Minitest::Skip"/>
            </testcase>
            <testcase name="test_bar" lineno="8" classname="ATest" assertions="1" time="X.XX" flaky_test="false">
-           <skipped type="test_bar"/>
+           <skipped type="Minitest::Assertion"/>
            </testcase>
            <testcase name="test_flaky" lineno="12" classname="ATest" assertions="1" time="X.XX" flaky_test="true">
-           <failure type="test_flaky" message="Expected false to be truthy.">
+           <failure type="Minitest::Assertion" message="Expected false to be truthy.">
        Skipped:
        test_flaky(ATest) [./test/fixtures/test/dummy_test.rb:17]:
        Expected false to be truthy.
@@ -295,14 +295,14 @@ module Integration
            <testcase name="test_flaky_passes" lineno="25" classname="ATest" assertions="1" time="X.XX" flaky_test="true">
            </testcase>
            <testcase name="test_flaky_fails_retry" lineno="21" classname="ATest" assertions="1" time="X.XX" flaky_test="true">
-           <failure type="test_flaky_fails_retry" message="Expected false to be truthy.">
+           <failure type="Minitest::Assertion" message="Expected false to be truthy.">
        Skipped:
        test_flaky_fails_retry(ATest) [./test/fixtures/test/dummy_test.rb:22]:
        Expected false to be truthy.
            </failure>
            </testcase>
            <testcase name="test_bar" lineno="8" classname="ATest" assertions="1" time="X.XX" flaky_test="false">
-           <failure type="test_bar" message="Expected false to be truthy.">
+           <failure type="Minitest::Assertion" message="Expected false to be truthy.">
        Failure:
        test_bar(ATest) [./test/fixtures/test/dummy_test.rb:9]:
        Expected false to be truthy.
@@ -311,12 +311,12 @@ module Integration
          </testsuite>
          <testsuite name="BTest" filepath="test/dummy_test.rb" skipped="1" failures="0" errors="1" tests="3" assertions="1" time="X.XX">
            <testcase name="test_bar" lineno="35" classname="BTest" assertions="0" time="X.XX" flaky_test="false">
-           <skipped type="test_bar"/>
+           <skipped type="TypeError"/>
            </testcase>
            <testcase name="test_foo" lineno="31" classname="BTest" assertions="1" time="X.XX" flaky_test="false">
            </testcase>
            <testcase name="test_bar" lineno="35" classname="BTest" assertions="0" time="X.XX" flaky_test="false">
-           <error type="test_bar" message="TypeError: String can't be coerced into Fixnum...">
+           <error type="TypeError" message="TypeError: String can't be coerced into Fixnum...">
        Failure:
        test_bar(BTest) [./test/fixtures/test/dummy_test.rb:36]:
        TypeError: String can't be coerced into Fixnum


### PR DESCRIPTION
cc @DazWorrall 
Fixes #77

## Problem

Using the test name for the error or failure type didn't make sense, wasn't aligned with the [Apache Ant's JUnit XML schema description](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd) of the error type and wasn't useful by redundantly including the test name again in this field.

The exception class wasn't previously included in the junit.xml and I would like to have to it to help determine the cause of a test failure when it is due to a timeout or infrastructure error.  It can also be useful to determine whether a test was actually skipped or was just retried.

## Solution

Use the exception class name for the type of the skipped, failure and error elements.