### PR TITLE
[WIP] gem misbehaves when there are preset minitest reporters

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -129,7 +129,8 @@ module Minitest
 
     def queue_reporters=(reporters)
       @queue_reporters ||= []
-      Reporters.use!(((Reporters.reporters || []) - @queue_reporters) + reporters)
+      #Reporters.use!(((Reporters.reporters || []) - @queue_reporters) + reporters)
+      Reporters.use!(reporters)
       Minitest.backtrace_filter.add_filter(%r{exe/minitest-queue|lib/ci/queue/})
       @queue_reporters = reporters
     end

--- a/ruby/test/fixtures/test/test_helper.rb
+++ b/ruby/test/fixtures/test/test_helper.rb
@@ -5,3 +5,5 @@ if ENV['MARSHAL']
 end
 
 require 'minitest/autorun'
+
+Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])


### PR DESCRIPTION
I see that in https://github.com/Shopify/ci-queue/blob/d23137212c183be51a9bc52294b169194879c926/ruby/lib/minitest/queue.rb#L130, the gem appends its own reporters to the existing list of reporters.

But when there's an existing reporter (at least it is the case with spec reporter) then gem misbehaves - it does not correctly detect failures. I suspect this is because in case of failure the existing reporter halts the chain of execution and therefore ci-queue reporters never know about the failure and think everything went well.

You can see tests failing: https://github.com/Shopify/ci-queue/pull/106/commits/94269de6179976694fc06c6b962baa68a4f481de

~You can see ignoring preset reporters fix the tests: https://github.com/Shopify/ci-queue/pull/106/commits/cf8082790c9ab48823ccf4463d0b97a65596de3f~