### PR TITLE
Add py37 and py38 to `tox`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ addons:
       - deadsnakes
     packages:
       - python3.6
+      - python3.7
+      - python3.7-distutils
+      - python3.8
+      - python3.8-distutils
 services:
   - redis-server
 language: ruby

--- a/python/Makefile
+++ b/python/Makefile
@@ -22,7 +22,7 @@ lint:
 autolint: autopep8 lint
 
 run_tests: clean
-	tox -e py27,py36 -- --durations=10 -vv tests
+	tox -e py27,py36,py37,py38 -- --durations=10 -vv tests
 
 test: autopep8 run_tests lint
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py36,py37,py38
 
 [testenv]
 commands = pytest {posargs:-vv}


### PR DESCRIPTION
To validate that we can run Python 3.7 and 3.8 on ciqueue let's add them to the tox runner!