### PR TITLE
Add TestTimeRecord

### DIFF
--- a/ruby/lib/ci/queue/redis.rb
+++ b/ruby/lib/ci/queue/redis.rb
@@ -7,6 +7,7 @@ require 'ci/queue/redis/grind'
 require 'ci/queue/redis/retry'
 require 'ci/queue/redis/supervisor'
 require 'ci/queue/redis/grind_supervisor'
+require 'ci/queue/redis/test_time_record'
 
 module CI
   module Queue

--- a/ruby/lib/ci/queue/redis/test_time_record.rb
+++ b/ruby/lib/ci/queue/redis/test_time_record.rb
@@ -30,7 +30,7 @@ module CI
         def record_test_name(test_name)
           redis.pipelined do
             redis.lpush(
-              key_to_list_all_test_names,
+              all_test_names_key,
               test_name.force_encoding(Encoding::BINARY),
             )
           end
@@ -39,7 +39,7 @@ module CI
 
         def fetch_all_test_names
           values = redis.pipelined do
-            redis.lrange(key_to_list_all_test_names, 0, -1)
+            redis.lrange(all_test_names_key, 0, -1)
           end
           values.flatten.map(&:to_s)
         end
@@ -52,7 +52,7 @@ module CI
           values.flatten.map(&:to_f)
         end
 
-        def key_to_list_all_test_names
+        def all_test_names_key
           "build:#{config.build_id}:list_of_test_names".force_encoding(Encoding::BINARY)
         end
 

--- a/ruby/lib/ci/queue/redis/test_time_record.rb
+++ b/ruby/lib/ci/queue/redis/test_time_record.rb
@@ -1,0 +1,65 @@
+module CI
+  module Queue
+    module Redis
+      class TestTimeRecord < Worker
+        def record(test_name, duration)
+          record_test_time(test_name, duration)
+          record_test_name(test_name)
+        end
+
+        def fetch
+          fetch_all_test_names.each_with_object({}) do |test_name, test_time_hash|
+            test_time_hash[test_name] = fetch_test_time(test_name)
+          end
+        end
+
+        private
+
+        attr_reader :redis
+
+        def record_test_time(test_name, duration)
+          redis.pipelined do
+            redis.lpush(
+              test_time_key(test_name),
+              duration.to_s.force_encoding(Encoding::BINARY),
+            )
+          end
+          nil
+        end
+
+        def record_test_name(test_name)
+          redis.pipelined do
+            redis.lpush(
+              key_to_list_all_test_names,
+              test_name.force_encoding(Encoding::BINARY),
+            )
+          end
+          nil
+        end
+
+        def fetch_all_test_names
+          values = redis.pipelined do
+            redis.lrange(key_to_list_all_test_names, 0, -1)
+          end
+          values.flatten.map(&:to_s)
+        end
+
+        def fetch_test_time(test_name)
+          values = redis.pipelined do
+            key = test_time_key(test_name)
+            redis.lrange(key, 0, -1)
+          end
+          values.flatten.map(&:to_f)
+        end
+
+        def key_to_list_all_test_names
+          "build:#{config.build_id}:list_of_test_names".force_encoding(Encoding::BINARY)
+        end
+
+        def test_time_key(test_name)
+          "build:#{config.build_id}:#{test_name}".force_encoding(Encoding::BINARY)
+        end
+      end
+    end
+  end
+end

--- a/ruby/test/ci/queue/redis/test_time_record_test.rb
+++ b/ruby/test/ci/queue/redis/test_time_record_test.rb
@@ -6,7 +6,7 @@ class CI::Queue::Redis::TestTimeRecordTest < Minitest::Test
     redis = Redis.new(url: redis_url)
     redis.flushdb
 
-    config ||= CI::Queue::Configuration.new(
+    config = CI::Queue::Configuration.new(
       timeout: 0.2,
       build_id: '42',
       worker_id: '1',

--- a/ruby/test/ci/queue/redis/test_time_record_test.rb
+++ b/ruby/test/ci/queue/redis/test_time_record_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class CI::Queue::Redis::TestTimeRecordTest < Minitest::Test
+  def setup
+    redis_url = "redis://#{ENV.fetch('REDIS_HOST', 'localhost')}/7"
+    redis = Redis.new(url: redis_url)
+    redis.flushdb
+
+    config ||= CI::Queue::Configuration.new(
+      timeout: 0.2,
+      build_id: '42',
+      worker_id: '1',
+      max_requeues: 1,
+      requeue_tolerance: 0.1,
+      max_consecutive_failures: 10,
+    )
+    @test_time_record = CI::Queue::Redis::TestTimeRecord.new(redis_url, config)
+  end
+
+  def test_fetch
+    @test_time_record.record('ATest#test_sucess', 0.1)
+    @test_time_record.record('ATest#test_sucess', 0.2)
+    record = @test_time_record.fetch
+    assert_equal 1, record.length
+    assert_equal [0.2, 0.1], record['ATest#test_sucess']
+  end
+end


### PR DESCRIPTION
Adding the class to store the run time of individual test during a grind in Redis.

Related https://github.com/Shopify/test-infra/issues/36

You can see the entire change at https://github.com/Shopify/ci-queue/pull/112/files