### PR TITLE
Add TestTimeRecorder

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -10,6 +10,7 @@ require 'minitest/queue/order_reporter'
 require 'minitest/queue/junit_reporter'
 require 'minitest/queue/grind_recorder'
 require 'minitest/queue/grind_reporter'
+require 'minitest/queue/test_time_recorder'
 
 module Minitest
   class Requeue < Skip

--- a/ruby/lib/minitest/queue/test_time_recorder.rb
+++ b/ruby/lib/minitest/queue/test_time_recorder.rb
@@ -1,0 +1,16 @@
+module Minitest
+  module Queue
+    class TestTimeRecorder < Minitest::Reporters::BaseReporter
+      def initialize(build:, **options)
+        super(options)
+        @build = build
+      end
+
+      def record(test)
+        return unless test.passed?
+        test_duration_in_milliseconds = test.time * 1000
+        @build.record(test.name, test_duration_in_milliseconds)
+      end
+    end
+  end
+end

--- a/ruby/test/minitest/queue/test_time_recorder_test.rb
+++ b/ruby/test/minitest/queue/test_time_recorder_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+module Minitest::Queue
+  class TestTimeRecorderTest < Minitest::Test
+    def setup
+      redis_url = "redis://#{ENV.fetch('REDIS_HOST', 'localhost')}/7"
+      redis = Redis.new(url: redis_url)
+      redis.flushdb
+
+      config ||= CI::Queue::Configuration.new(
+        timeout: 0.2,
+        build_id: '42',
+        worker_id: '1',
+        max_requeues: 1,
+        requeue_tolerance: 0.1,
+        max_consecutive_failures: 10,
+      )
+      @test_time_record = CI::Queue::Redis::TestTimeRecord.new(redis_url, config)
+      @test_time_recorder = TestTimeRecorder.new(build: @test_time_record)
+    end
+
+    def test_record_when_test_pass
+      test = MiniTest::Mock.new
+      test.expect(:passed?, true)
+      test.expect(:name, 'some test')
+      test.expect(:time, 0.1) # in seconds
+      @test_time_recorder.record(test)
+
+      record = @test_time_record.fetch
+      assert_equal 1, record.length
+      assert_equal [100], record['some test'] # in milliseconds
+    end
+
+    def test_record_do_nothing_when_test_failed
+      test = MiniTest::Mock.new
+      test.expect(:passed?, false)
+      @test_time_recorder.record(test)
+
+      record = @test_time_record.fetch
+      assert_empty record
+    end
+  end
+end


### PR DESCRIPTION
Adding the class to store the run time of individual test during a grind to a build being passed in.

Related https://github.com/Shopify/test-infra/issues/36

You can see the entire change at https://github.com/Shopify/ci-queue/pull/112/files