### PR TITLE
add --max-test-duration feature

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -3,6 +3,7 @@ module CI
     class Configuration
       attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count, :failure_file
       attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
+      attr_accessor :max_test_duration, :max_test_duration_percentile
       attr_reader :circuit_breakers
 
       class << self
@@ -27,7 +28,8 @@ module CI
       def initialize(
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
-        grind_count: nil, max_duration: nil, failure_file: nil
+        grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
+        max_test_duration_percentile: 0.5
       )
         @circuit_breakers = [CircuitBreaker::Disabled]
         @build_id = build_id
@@ -41,6 +43,8 @@ module CI
         @statsd_endpoint = statsd_endpoint
         @timeout = timeout
         @worker_id = worker_id
+        @max_test_duration = max_test_duration
+        @max_test_duration_percentile = max_test_duration_percentile
         self.max_duration = max_duration
         self.max_consecutive_failures = max_consecutive_failures
       end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -11,6 +11,7 @@ require 'minitest/queue/junit_reporter'
 require 'minitest/queue/grind_recorder'
 require 'minitest/queue/grind_reporter'
 require 'minitest/queue/test_time_recorder'
+require 'minitest/queue/test_time_reporter'
 
 module Minitest
   class Requeue < Skip

--- a/ruby/lib/minitest/queue/test_time_reporter.rb
+++ b/ruby/lib/minitest/queue/test_time_reporter.rb
@@ -1,0 +1,69 @@
+require 'minitest/reporters'
+
+module Minitest
+  module Queue
+    class TestTimeReporter < Minitest::Reporters::BaseReporter
+      include ::CI::Queue::OutputHelpers
+
+      def initialize(build:, limit: nil, percentile: nil, **options)
+        super(options)
+        @test_time_hash = build.fetch
+        @limit = limit
+        @percentile = percentile
+        @success = true
+      end
+
+      def report
+        return if limit.nil? || test_time_hash.empty?
+
+        puts '+++ Test Time Report'
+
+        if offending_tests.empty?
+          msg = "The #{humanized_percentile} of test execution time is within #{limit} milliseconds."
+          puts green(msg)
+          return
+        end
+
+        @success = false
+        puts <<~EOS
+          #{red("Detected #{offending_tests.size} test(s) over the desired time limit.")}
+          Please make them faster than #{limit}ms in the #{humanized_percentile} percentile.
+        EOS
+        offending_tests.each do |test_name, duration|
+          puts "#{red(test_name)}: #{duration}ms"
+        end
+      end
+
+      def success?
+        @success
+      end
+
+      def record(*)
+        raise NotImplementedError
+      end
+
+      private
+
+      attr_reader :test_time_hash, :limit, :percentile
+
+      def humanized_percentile
+        percentile_in_percentage = percentile * 100
+        "#{percentile_in_percentage.to_i}th"
+      end
+
+      def offending_tests
+        @offending_tests ||= begin
+          test_time_hash.each_with_object({}) do |(test_name, durations), offenders|
+            duration = calculate_percentile(durations)
+            next if duration <= limit
+            offenders[test_name] = duration
+          end
+        end
+      end
+
+      def calculate_percentile(array)
+        array.sort[(percentile * array.length).ceil - 1]
+      end
+    end
+  end
+end

--- a/ruby/test/integration/grind_redis_test.rb
+++ b/ruby/test/integration/grind_redis_test.rb
@@ -133,7 +133,6 @@ module Integration
       assert run_count < grind_count
     end
 
-
     def test_can_grind_multiple_things
       system(
         { 'BUILDKITE' => '1' },
@@ -187,6 +186,125 @@ module Integration
       EOS
       assert_equal expected.strip, output
       assert_empty err
+    end
+
+    def test_grind_max_test_duration_passing
+      system(
+        { 'BUILDKITE' => '1' },
+        @exe, 'grind',
+        '--queue', @redis_url,
+        '--seed', 'foobar',
+        '--build', '1',
+        '--worker', '1',
+        '--timeout', '1',
+        '--grind-count', '10',
+        '--grind-list', 'grind_list_success.txt',
+        '-Itest',
+        'test/dummy_test.rb',
+        chdir: 'test/fixtures/',
+      )
+
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          @exe, 'report_grind',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '5',
+          '--max-test-duration', '1000',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      output = normalize(out).strip
+      expected = <<~EOS
+        +++ Results
+        all tests passed every time, grinding did not uncover any flakiness
+        +++ Test Time Report
+        The 50th of test execution time is within 1000.0 milliseconds.
+      EOS
+      assert_equal expected.strip, output
+      assert_empty err
+    end
+
+    def test_grind_max_test_duration_failing
+      system(
+        { 'BUILDKITE' => '1' },
+        @exe, 'grind',
+        '--queue', @redis_url,
+        '--seed', 'foobar',
+        '--build', '1',
+        '--worker', '1',
+        '--timeout', '1',
+        '--grind-count', '10',
+        '--grind-list', 'grind_list_success.txt',
+        '-Itest',
+        'test/dummy_test.rb',
+        chdir: 'test/fixtures/',
+      )
+
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          @exe, 'report_grind',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '5',
+          '--max-test-duration', '0.00001',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      output = normalize(out).strip
+      expected = <<~EOS
+        +++ Results
+        all tests passed every time, grinding did not uncover any flakiness
+        +++ Test Time Report
+        Detected 1 test(s) over the desired time limit.
+        Please make them faster than 1.0e-05ms in the 50th percentile.
+        test_flaky_passes:
+      EOS
+      assert output.start_with?(expected.strip)
+      assert_empty err
+    end
+
+    def test_grind_max_test_duration_percentile_outside_range
+      system(
+        { 'BUILDKITE' => '1' },
+        @exe, 'grind',
+        '--queue', @redis_url,
+        '--seed', 'foobar',
+        '--build', '1',
+        '--worker', '1',
+        '--timeout', '1',
+        '--grind-count', '10',
+        '--grind-list', 'grind_list_success.txt',
+        '-Itest',
+        'test/dummy_test.rb',
+        chdir: 'test/fixtures/',
+      )
+
+      _, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          @exe, 'report_grind',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '5',
+          '--max-test-duration', '1000',
+          '--max-test-duration-percentile', '1.1',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      refute_empty err
+      assert err.include?("--max-test-duration-percentile must be within range (0, 1] (OptionParser::ParseError)")
     end
   end
 end

--- a/ruby/test/minitest/queue/test_time_reporter_test.rb
+++ b/ruby/test/minitest/queue/test_time_reporter_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+module Minitest
+  module Queue
+    class TimeReporterTest < Minitest::Test
+      include OutputTestHelpers
+
+      def test_report_no_offending_tests
+        build = mock_build({'some test': [0.01, 0.02, 0.2]})
+        reporter = TestTimeReporter.new(build: build, limit: 0.1, percentile: 0.5)
+
+        output, err = capture_subprocess_io do
+          reporter.report
+        end
+
+        expected_output = <<~EOS
+          +++ Test Time Report
+          \e[32mThe 50th of test execution time is within 0.1 milliseconds.\e[0m
+        EOS
+        assert_equal expected_output, output
+        assert_empty err
+        assert reporter.success?
+      end
+
+      def test_report_not_turned_on
+        build = mock_build({'some test': [0.01, 0.02, 0.2]})
+        reporter = TestTimeReporter.new(build: build)
+
+        output, err = capture_subprocess_io do
+          reporter.report
+        end
+
+        assert_equal "", output
+        assert_empty err
+        assert reporter.success?
+      end
+
+      def test_report_found_offending_tests
+        build = mock_build({'some test': [0.01, 0.03, 0.2]})
+        reporter = TestTimeReporter.new(build: build, limit: 0.02, percentile: 0.5)
+
+        output, err = capture_subprocess_io do
+          reporter.report
+        end
+
+        expected_output = <<~EOS
+          +++ Test Time Report
+          Detected 1 test(s) over the desired time limit.
+          Please make them faster than 0.02ms in the 50th percentile.
+          some test: 0.03ms
+        EOS
+        assert_equal expected_output, normalize(output)
+        assert_empty err
+        refute reporter.success?
+      end
+
+      private
+
+      def mock_build(test_time_hash)
+        build = MiniTest::Mock.new
+        build.expect(:fetch, test_time_hash)
+        build
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `--max-test-duration` and `--max-test-duration-percentile` to grind.

Related https://github.com/Shopify/test-infra/issues/36

You can see the entire change at https://github.com/Shopify/ci-queue/pull/112/files