### PR TITLE
save test metrics

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -1,5 +1,6 @@
 test/fixtures/log/junit.xml
 test/fixtures/log/test_order.log
+test/fixtures/log/test_data.json
 /.byebug_history
 /.bundle/
 /.yardoc

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -9,6 +9,7 @@ require 'minitest/queue/build_status_recorder'
 require 'minitest/queue/build_status_reporter'
 require 'minitest/queue/order_reporter'
 require 'minitest/queue/junit_reporter'
+require 'minitest/queue/test_data_reporter'
 require 'minitest/queue/grind_recorder'
 require 'minitest/queue/grind_reporter'
 require 'minitest/queue/test_time_recorder'
@@ -49,7 +50,7 @@ module Minitest
     end
 
     def result_label
-      "Skipped"
+      "Flaked"
     end
 
     def backtrace

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -61,6 +61,7 @@ module Minitest
           LocalRequeueReporter.new,
           BuildStatusRecorder.new(build: queue.build),
           JUnitReporter.new,
+          TestDataReporter.new(namespace: queue_config&.namespace),
           OrderReporter.new(path: 'log/test_order.log'),
         ]
         if queue_config.statsd_endpoint
@@ -95,6 +96,7 @@ module Minitest
         Minitest.queue = queue
         reporters = [
           GrindRecorder.new(build: reporter_queue.build),
+          TestDataReporter.new(namespace: queue_config&.namespace),
           TestTimeRecorder.new(build: test_time_record)
         ]
         if queue_config.statsd_endpoint

--- a/ruby/lib/minitest/queue/test_data.rb
+++ b/ruby/lib/minitest/queue/test_data.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+require 'minitest/reporters'
+require 'fileutils'
+
+module Minitest
+  module Queue
+    class TestData
+      attr_reader :namespace, :test_index
+
+      def initialize(test:, index:, namespace:, base_path:)
+        @test = test
+        @base_path = base_path
+        @namespace = namespace
+        @test_index = index
+      end
+
+      def test_id
+        "#{test_suite}##{test_name}"
+      end
+
+      def test_name
+        @test.name
+      end
+
+      def test_suite
+        @test.klass
+      end
+
+      def test_retried
+        @test.requeued?
+      end
+
+      def test_result
+        if @test.passed?
+          'success'
+        elsif !@test.requeued? && @test.skipped?
+          'skipped'
+        elsif @test.error?
+          'error'
+        elsif @test.failure
+          'failure'
+        else
+          'undefined'
+        end
+      end
+
+      def test_assertions
+        @test.assertions
+      end
+
+      def test_duration
+        @test.time
+      end
+
+      def test_file_path
+        path = @test.source_location.first
+        relative_path_for(path)
+      end
+
+      def test_file_line_number
+        @test.source_location.last
+      end
+
+      # Error class only considers failures wheras the other error fields also consider skips
+      def error_class
+        return nil unless @test.failure
+
+        @test.failure.error.class.name
+      end
+
+      def error_message
+        return nil unless @test.failure
+
+        @test.failure.message
+      end
+
+      def error_file_path
+        return nil unless @test.failure
+
+        path = error_location(@test.failure).first
+        relative_path_for(path)
+      end
+
+      def error_file_number
+        return nil unless @test.failure
+
+        error_location(@test.failure).last
+      end
+
+      def to_h
+        {
+          namespace: namespace,
+          test_id: test_id,
+          test_name: test_name,
+          test_suite: test_suite,
+          test_result: test_result,
+          test_index: test_index,
+          test_result_ignored: @test.flaked?,
+          test_retried: test_retried,
+          test_assertions: test_assertions,
+          test_duration: test_duration,
+          test_file_path: test_file_path,
+          test_file_line_number: test_file_line_number,
+          error_class: error_class,
+          error_message: error_message,
+          error_file_path: error_file_path,
+          error_file_number: error_file_number,
+        }
+      end
+
+      private
+
+      def relative_path_for(path)
+        file_path = Pathname.new(path)
+        base_path = Pathname.new(@base_path)
+        file_path.relative_path_from(base_path)
+      end
+
+      def error_location(exception)
+        @error_location ||= begin
+          last_before_assertion = ''
+          exception.backtrace.reverse_each do |s|
+            break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
+
+            last_before_assertion = s
+          end
+          path = last_before_assertion.sub(/:in .*$/, '')
+          # the path includes the linenumber at the end,
+          # which is seperated by a :
+          # rpartition splits the string at the last occurence of :
+          result = path.rpartition(':')
+          # We return [path, linenumber] here
+          [result.first, result.last.to_i]
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/minitest/queue/test_data_reporter.rb
+++ b/ruby/lib/minitest/queue/test_data_reporter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'minitest/reporters'
+require 'fileutils'
+require 'json'
+
+require 'minitest/queue/test_data'
+
+module Minitest
+  module Queue
+    class TestDataReporter < Minitest::Reporters::BaseReporter
+      def initialize(report_path: 'log/test_data.json', base_path: nil, namespace: '')
+        super({})
+        @report_path = File.absolute_path(report_path)
+        @base_path = base_path || Dir.pwd
+        @namespace = namespace || ''
+      end
+
+      def report
+        super
+
+        result = tests.map.with_index do |test, index|
+          Queue::TestData.new(test: test, index: index,
+                              base_path: @base_path, namespace: @namespace).to_h
+        end.to_json
+
+        dirname = File.dirname(@report_path)
+        FileUtils.mkdir_p(dirname)
+        File.open(@report_path, 'w+') { |file| file << result }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to output data on test results, which is we use for data analysis.
Doing this through json instead of the junit xml gives us an easier time using it and also more flexibility.

ref https://github.com/Shopify/test-infra/issues/100