### PR TITLE
Add option to disable TestTimeReporter

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -4,7 +4,7 @@ module CI
     class Configuration
       attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count, :failure_file
       attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
-      attr_accessor :max_test_duration, :max_test_duration_percentile
+      attr_accessor :max_test_duration, :max_test_duration_percentile, :track_execution_duration
       attr_reader :circuit_breakers
 
       class << self
@@ -30,7 +30,7 @@ module CI
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
-        max_test_duration_percentile: 0.5
+        max_test_duration_percentile: 0.5, track_execution_duration: false
       )
         @circuit_breakers = [CircuitBreaker::Disabled]
         @build_id = build_id
@@ -46,6 +46,7 @@ module CI
         @worker_id = worker_id
         @max_test_duration = max_test_duration
         @max_test_duration_percentile = max_test_duration_percentile
+        @track_execution_duration = track_execution_duration
         self.max_duration = max_duration
         self.max_consecutive_failures = max_consecutive_failures
       end

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -4,7 +4,7 @@ module CI
     class Configuration
       attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count, :failure_file
       attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
-      attr_accessor :max_test_duration, :max_test_duration_percentile, :track_execution_duration
+      attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
       attr_reader :circuit_breakers
 
       class << self
@@ -30,7 +30,7 @@ module CI
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
-        max_test_duration_percentile: 0.5, track_execution_duration: false
+        max_test_duration_percentile: 0.5, track_test_duration: false
       )
         @circuit_breakers = [CircuitBreaker::Disabled]
         @build_id = build_id
@@ -46,7 +46,7 @@ module CI
         @worker_id = worker_id
         @max_test_duration = max_test_duration
         @max_test_duration_percentile = max_test_duration_percentile
-        @track_execution_duration = track_execution_duration
+        @track_test_duration = track_test_duration
         self.max_duration = max_duration
         self.max_consecutive_failures = max_consecutive_failures
       end

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.17.0'
+    VERSION = '0.17.1'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -98,7 +98,7 @@ module Minitest
           TestDataReporter.new(namespace: queue_config&.namespace),
         ]
 
-        if queue_config.track_execution_duration
+        if queue_config.track_test_duration
           test_time_record = CI::Queue::Redis::TestTimeRecord.new(queue_url, queue_config)
           reporters << TestTimeRecorder.new(build: test_time_record)
         end
@@ -209,7 +209,7 @@ module Minitest
         grind_reporter = GrindReporter.new(build: supervisor.build)
         grind_reporter.report
 
-        test_time_reporter_success = if queue_config.track_execution_duration
+        test_time_reporter_success = if queue_config.track_test_duration
           test_time_record = CI::Queue::Redis::TestTimeRecord.new(queue_url, queue_config)
           test_time_reporter = Minitest::Queue::TestTimeReporter.new(
             build: test_time_record,
@@ -429,8 +429,8 @@ module Minitest
           help = <<~EOS
             Must set this option in report and report_grind command if you set --max-test-duration in the report_grind
           EOS
-          opts.on('--track-execution-duration', help) do
-            queue_config.track_execution_duration = true
+          opts.on('--track-test-duration', help) do
+            queue_config.track_test_duration = true
           end
 
           help = <<~EOS

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -91,14 +91,18 @@ module Minitest
         queue_config.grind_count = grind_count
 
         reporter_queue = CI::Queue::Redis::Grind.new(queue_url, queue_config)
-        test_time_record = CI::Queue::Redis::TestTimeRecord.new(queue_url, queue_config)
 
         Minitest.queue = queue
         reporters = [
           GrindRecorder.new(build: reporter_queue.build),
           TestDataReporter.new(namespace: queue_config&.namespace),
-          TestTimeRecorder.new(build: test_time_record)
         ]
+
+        if queue_config.track_execution_duration
+          test_time_record = CI::Queue::Redis::TestTimeRecord.new(queue_url, queue_config)
+          reporters << TestTimeRecorder.new(build: test_time_record)
+        end
+
         if queue_config.statsd_endpoint
           reporters << Minitest::Reporters::StatsdReporter.new(statsd_endpoint: queue_config.statsd_endpoint)
         end
@@ -205,15 +209,21 @@ module Minitest
         grind_reporter = GrindReporter.new(build: supervisor.build)
         grind_reporter.report
 
-        test_time_record = CI::Queue::Redis::TestTimeRecord.new(queue_url, queue_config)
-        test_time_reporter = Minitest::Queue::TestTimeReporter.new(
-          build: test_time_record,
-          limit: queue_config.max_test_duration,
-          percentile: queue_config.max_test_duration_percentile,
-        )
-        test_time_reporter.report
+        test_time_reporter_success = if queue_config.track_execution_duration
+          test_time_record = CI::Queue::Redis::TestTimeRecord.new(queue_url, queue_config)
+          test_time_reporter = Minitest::Queue::TestTimeReporter.new(
+            build: test_time_record,
+            limit: queue_config.max_test_duration,
+            percentile: queue_config.max_test_duration_percentile,
+          )
+          test_time_reporter.report
 
-        exit! grind_reporter.success? && test_time_reporter.success? ? 0 : 1
+          test_time_reporter.success?
+        else
+          true
+        end
+
+        exit! grind_reporter.success? && test_time_reporter_success ? 0 : 1
       end
 
       private
@@ -414,6 +424,13 @@ module Minitest
           opts.separator ""
           opts.on('--max-consecutive-failures MAX', Integer, help) do |max|
             queue_config.max_consecutive_failures = max
+          end
+
+          help = <<~EOS
+            Must set this option in report and report_grind command if you set --max-test-duration in the report_grind
+          EOS
+          opts.on('--track-execution-duration', help) do
+            queue_config.track_execution_duration = true
           end
 
           help = <<~EOS

--- a/ruby/test/integration/grind_redis_test.rb
+++ b/ruby/test/integration/grind_redis_test.rb
@@ -200,7 +200,7 @@ module Integration
         '--timeout', '1',
         '--grind-count', '10',
         '--grind-list', 'grind_list_success.txt',
-        '--track-execution-duration',
+        '--track-test-duration',
         '-Itest',
         'test/dummy_test.rb',
         chdir: 'test/fixtures/',
@@ -216,7 +216,7 @@ module Integration
           '--worker', '1',
           '--timeout', '5',
           '--max-test-duration', '1000',
-          '--track-execution-duration',
+          '--track-test-duration',
           chdir: 'test/fixtures/',
         )
       end
@@ -243,7 +243,7 @@ module Integration
         '--timeout', '1',
         '--grind-count', '10',
         '--grind-list', 'grind_list_success.txt',
-        '--track-execution-duration',
+        '--track-test-duration',
         '-Itest',
         'test/dummy_test.rb',
         chdir: 'test/fixtures/',
@@ -259,7 +259,7 @@ module Integration
           '--worker', '1',
           '--timeout', '5',
           '--max-test-duration', '0.00001',
-          '--track-execution-duration',
+          '--track-test-duration',
           chdir: 'test/fixtures/',
         )
       end
@@ -288,7 +288,7 @@ module Integration
         '--timeout', '1',
         '--grind-count', '10',
         '--grind-list', 'grind_list_success.txt',
-        '--track-execution-duration',
+        '--track-test-duration',
         '-Itest',
         'test/dummy_test.rb',
         chdir: 'test/fixtures/',
@@ -305,7 +305,7 @@ module Integration
           '--timeout', '5',
           '--max-test-duration', '1000',
           '--max-test-duration-percentile', '1.1',
-          '--track-execution-duration',
+          '--track-test-duration',
           chdir: 'test/fixtures/',
         )
       end

--- a/ruby/test/integration/grind_redis_test.rb
+++ b/ruby/test/integration/grind_redis_test.rb
@@ -200,6 +200,7 @@ module Integration
         '--timeout', '1',
         '--grind-count', '10',
         '--grind-list', 'grind_list_success.txt',
+        '--track-execution-duration',
         '-Itest',
         'test/dummy_test.rb',
         chdir: 'test/fixtures/',
@@ -215,6 +216,7 @@ module Integration
           '--worker', '1',
           '--timeout', '5',
           '--max-test-duration', '1000',
+          '--track-execution-duration',
           chdir: 'test/fixtures/',
         )
       end
@@ -241,6 +243,7 @@ module Integration
         '--timeout', '1',
         '--grind-count', '10',
         '--grind-list', 'grind_list_success.txt',
+        '--track-execution-duration',
         '-Itest',
         'test/dummy_test.rb',
         chdir: 'test/fixtures/',
@@ -256,6 +259,7 @@ module Integration
           '--worker', '1',
           '--timeout', '5',
           '--max-test-duration', '0.00001',
+          '--track-execution-duration',
           chdir: 'test/fixtures/',
         )
       end
@@ -284,6 +288,7 @@ module Integration
         '--timeout', '1',
         '--grind-count', '10',
         '--grind-list', 'grind_list_success.txt',
+        '--track-execution-duration',
         '-Itest',
         'test/dummy_test.rb',
         chdir: 'test/fixtures/',
@@ -300,6 +305,7 @@ module Integration
           '--timeout', '5',
           '--max-test-duration', '1000',
           '--max-test-duration-percentile', '1.1',
+          '--track-execution-duration',
           chdir: 'test/fixtures/',
         )
       end


### PR DESCRIPTION
Related: https://github.com/Shopify/test-infra/issues/183