### PR TITLE
Increase wait_for_master timeout to 30s

### DIFF
--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -38,7 +38,7 @@ module CI
           total - size
         end
 
-        def wait_for_master(timeout: 10)
+        def wait_for_master(timeout: 30)
           return true if master?
           (timeout * 10 + 1).to_i.times do
             if queue_initialized?
@@ -47,7 +47,7 @@ module CI
               sleep 0.1
             end
           end
-          raise LostMaster, "The master worker is still `#{master_status}` after 10 seconds waiting."
+          raise LostMaster, "The master worker is still `#{master_status}` after #{timeout} seconds waiting."
         end
 
         def workers_count

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.17.1'
+    VERSION = '0.17.2'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end


### PR DESCRIPTION
- Increase default wait_for_master timeout from 10s to 30s.
- Bump patch version

This could mitigate issues with timeouts in worker polling: https://github.com/Shopify/ci-queue/blob/c6e7640c6b54bd6ccebdeedfe3c371fe86959238/ruby/lib/ci/queue/redis/worker.rb#L47

We can implement exponential backoff at a later time when needed.