### PR TITLE
Bump dev.yml to ruby 2.6.5

### DIFF
--- a/ruby/dev.yml
+++ b/ruby/dev.yml
@@ -3,7 +3,7 @@
 name: ci-queue
 
 up:
-- ruby: 2.3.7
+- ruby: 2.6.5
 - bundler
 - railgun
 


### PR DESCRIPTION
This fixes the `dev up` on my machine.