### PR TITLE
add error class to failure file

### DIFF
--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -27,6 +27,7 @@ module Minitest
           test_line: test_line,
           test_and_module_name: "#{test.klass}##{test.name}",
           test_name: test.name,
+          error_class: test.failure.exception.class.name,
           output: to_s,
         }
       end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -448,6 +448,7 @@ module Integration
           test_file: "ci-queue/ruby/test/fixtures/test/dummy_test.rb",
           test_line: 9,
           test_and_module_name: "ATest#test_bar",
+          error_class: "Minitest::Assertion",
           test_name: "test_bar",
         }
 
@@ -455,6 +456,7 @@ module Integration
         assert_equal failure[:test_line], expected[:test_line]
         assert_equal failure[:test_and_module_name], expected[:test_and_module_name]
         assert_equal failure[:test_name], expected[:test_name]
+        assert_equal failure[:error_class], expected[:error_class]
       end
     end
 


### PR DESCRIPTION
In order for us to ignore certain types of intermittent test failures from being removed from the codebase we have to know what the error class is. This PR adds the error class to the failure file.

ref https://github.com/Shopify/test-infra/issues/225