### PR TITLE
Add a ttl for redis keys

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -4,7 +4,7 @@ module CI
     class Configuration
       attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count, :failure_file
       attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
-      attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
+      attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration, :report_expires_in
       attr_reader :circuit_breakers
 
       class << self
@@ -30,7 +30,7 @@ module CI
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
-        max_test_duration_percentile: 0.5, track_test_duration: false
+        max_test_duration_percentile: 0.5, track_test_duration: false, report_expires_in: 28_800
       )
         @circuit_breakers = [CircuitBreaker::Disabled]
         @build_id = build_id
@@ -47,6 +47,7 @@ module CI
         @max_test_duration = max_test_duration
         @max_test_duration_percentile = max_test_duration_percentile
         @track_test_duration = track_test_duration
+        @report_expires_in = report_expires_in
         self.max_duration = max_duration
         self.max_consecutive_failures = max_consecutive_failures
       end

--- a/ruby/lib/ci/queue/redis/build_record.rb
+++ b/ruby/lib/ci/queue/redis/build_record.rb
@@ -41,6 +41,7 @@ module CI
               id.dup.force_encoding(Encoding::BINARY),
               payload.dup.force_encoding(Encoding::BINARY),
             )
+            redis.expire(key('error-reports'), config.report_expires_in)
             record_stats(stats)
           end
           nil
@@ -81,6 +82,7 @@ module CI
           return unless stats
           stats.each do |stat_name, stat_value|
             redis.hset(key(stat_name), config.worker_id, stat_value)
+            redis.expire(key(stat_name), config.report_expires_in)
           end
         end
 

--- a/ruby/lib/ci/queue/redis/grind_record.rb
+++ b/ruby/lib/ci/queue/redis/grind_record.rb
@@ -16,6 +16,7 @@ module CI
               key('error-reports'),
               payload.force_encoding(Encoding::BINARY),
             )
+            redis.expire(key('error-reports'), config.report_expires_in)
             record_stats(stats)
           end
           nil
@@ -58,6 +59,7 @@ module CI
           return unless stats
           stats.each do |stat_name, stat_value|
             redis.hset(key(stat_name), config.worker_id, stat_value)
+            redis.expire(key(stat_name), config.report_expires_in)
           end
         end
       end

--- a/ruby/lib/ci/queue/redis/test_time_record.rb
+++ b/ruby/lib/ci/queue/redis/test_time_record.rb
@@ -24,6 +24,7 @@ module CI
               test_time_key(test_name),
               duration.to_s.force_encoding(Encoding::BINARY),
             )
+            redis.expire(test_time_key(test_name), config.report_expires_in)
           end
           nil
         end
@@ -34,6 +35,7 @@ module CI
               all_test_names_key,
               test_name.dup.force_encoding(Encoding::BINARY),
             )
+            redis.expire(all_test_names_key, config.report_expires_in)
           end
           nil
         end

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -162,6 +162,10 @@ module CI
               redis.lpush(key('queue'), tests) unless tests.empty?
               redis.set(key('total'), @total)
               redis.set(key('master-status'), 'ready')
+
+              redis.expire(key('queue'), config.report_expires_in)
+              redis.expire(key('total'), config.report_expires_in)
+              redis.expire(key('master-status'), config.report_expires_in)
             end
           end
           register

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -459,6 +459,14 @@ module Minitest
             end
           end
 
+          help = <<~EOS
+            Defines how long the test report remain after the test run, in seconds.
+            Defaults to 28,800 (8 hours)
+          EOS
+          opts.on("--report-expires-in SECONDS", Integer, help) do |time|
+            queue.config.report_expires_in = time
+          end
+
           opts.separator ""
           opts.separator "    retry: Replays a previous run in the same order."
 

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -157,6 +157,15 @@ module RSpec
           queue_config.max_consecutive_failures = Integer(max)
         end
 
+        help = <<~EOS
+          Defines how long the test report remain after the test run, in seconds.
+          Defaults to 28,800 (8 hours)
+        EOS
+        parser.separator ""
+        parser.on("--report-expires-in SECONDS", *help) do |time|
+          queue.config.report_expires_in = Integer(time)
+        end
+
         parser
       end
 


### PR DESCRIPTION
Following on from #131 

This adds a command line argument for rspec for an expiry time, and sets the expiry for keys in redis when they are set.

I didn't look at the minitest files, but I can take a look if you're happy with this approach.