### PR TITLE
add max test failures feature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby 2.6.5
+      - name: Set up Ruby 2.6.x
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.5
+          ruby-version: 2.6.x
       - name: Run Ruby tests
         run: |
           bin/before-install

--- a/ruby/lib/ci/queue/circuit_breaker.rb
+++ b/ruby/lib/ci/queue/circuit_breaker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module CI
   module Queue
-    class CircuitBreaker
+    module CircuitBreaker
       module Disabled
         extend self
 
@@ -50,25 +50,27 @@ module CI
         end
       end
 
-      def initialize(max_consecutive_failures:)
-        @max = max_consecutive_failures
-        @consecutive_failures = 0
-      end
+      class MaxConsecutiveFailures
+        def initialize(max_consecutive_failures:)
+          @max = max_consecutive_failures
+          @consecutive_failures = 0
+        end
 
-      def report_failure!
-        @consecutive_failures += 1
-      end
+        def report_failure!
+          @consecutive_failures += 1
+        end
 
-      def report_success!
-        @consecutive_failures = 0
-      end
+        def report_success!
+          @consecutive_failures = 0
+        end
 
-      def open?
-        @consecutive_failures >= @max
-      end
+        def open?
+          @consecutive_failures >= @max
+        end
 
-      def message
-        'This worker is exiting early because it encountered too many consecutive test failures, probably because of some corrupted state.'
+        def message
+          'This worker is exiting early because it encountered too many consecutive test failures, probably because of some corrupted state.'
+        end
       end
     end
   end

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -5,6 +5,7 @@ module CI
       attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count, :failure_file
       attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
       attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
+      attr_accessor :max_visible_tests
       attr_reader :circuit_breakers
 
       class << self
@@ -30,30 +31,31 @@ module CI
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
-        max_test_duration_percentile: 0.5, track_test_duration: false
+        max_test_duration_percentile: 0.5, track_test_duration: false, max_visible_tests: nil
       )
-        @circuit_breakers = [CircuitBreaker::Disabled]
         @build_id = build_id
+        @circuit_breakers = [CircuitBreaker::Disabled]
         @failure_file = failure_file
         @flaky_tests = flaky_tests
         @grind_count = grind_count
         @max_requeues = max_requeues
+        @max_test_duration = max_test_duration
+        @max_test_duration_percentile = max_test_duration_percentile
+        @max_visible_tests = max_visible_tests
         @namespace = namespace
         @requeue_tolerance = requeue_tolerance
         @seed = seed
         @statsd_endpoint = statsd_endpoint
         @timeout = timeout
-        @worker_id = worker_id
-        @max_test_duration = max_test_duration
-        @max_test_duration_percentile = max_test_duration_percentile
         @track_test_duration = track_test_duration
-        self.max_duration = max_duration
+        @worker_id = worker_id
         self.max_consecutive_failures = max_consecutive_failures
+        self.max_duration = max_duration
       end
 
       def max_consecutive_failures=(max)
         if max
-          @circuit_breakers << CircuitBreaker.new(max_consecutive_failures: max)
+          @circuit_breakers << CircuitBreaker::MaxConsecutiveFailures.new(max_consecutive_failures: max)
         end
       end
 

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -5,7 +5,7 @@ module CI
       attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count, :failure_file
       attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
       attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
-      attr_accessor :max_visible_tests
+      attr_accessor :max_test_failed
       attr_reader :circuit_breakers
 
       class << self
@@ -31,7 +31,7 @@ module CI
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
-        max_test_duration_percentile: 0.5, track_test_duration: false, max_visible_tests: nil
+        max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil
       )
         @build_id = build_id
         @circuit_breakers = [CircuitBreaker::Disabled]
@@ -41,7 +41,7 @@ module CI
         @max_requeues = max_requeues
         @max_test_duration = max_test_duration
         @max_test_duration_percentile = max_test_duration_percentile
-        @max_visible_tests = max_visible_tests
+        @max_test_failed = max_test_failed
         @namespace = namespace
         @requeue_tolerance = requeue_tolerance
         @seed = seed

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -61,8 +61,18 @@ module CI
           end
         end
 
-        def increment_visible_failures
-          redis.incr(key('visible_failures'))
+        def increment_test_failed
+          redis.incr(key('test_failed_count'))
+        end
+
+        def test_failed
+          redis.get(key('test_failed_count')).to_i
+        end
+
+        def max_test_failed?
+          return false if config.max_test_failed.nil?
+
+          test_failed >= config.max_test_failed
         end
 
         private

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -61,6 +61,10 @@ module CI
           end
         end
 
+        def increment_visible_failures
+          redis.incr(key('visible_failures'))
+        end
+
         private
 
         attr_reader :redis, :redis_url

--- a/ruby/lib/ci/queue/redis/build_record.rb
+++ b/ruby/lib/ci/queue/redis/build_record.rb
@@ -54,14 +54,10 @@ module CI
           nil
         end
 
-        def visible_failures
-          redis.get(key('visible_failures')).to_i
-        end
+        def max_test_failed?
+          return false if config.max_test_failed.nil?
 
-        def max_visible_failures_reached?
-          return false if config.max_visible_tests.nil?
-
-          build.visible_failures >= config.max_visible_tests
+          @queue.test_failures >= config.max_test_failed
         end
 
         def error_reports

--- a/ruby/lib/ci/queue/redis/supervisor.rb
+++ b/ruby/lib/ci/queue/redis/supervisor.rb
@@ -22,13 +22,13 @@ module CI
           yield if block_given?
 
           time_left = config.timeout
-          until exhausted? || time_left <= 0 || build.max_visible_failures_reached?
+          until exhausted? || time_left <= 0 || max_test_failed?
             sleep 1
             time_left -= 1
 
             yield if block_given?
           end
-          exhausted? || build.max_visible_failures_reached?
+          exhausted?
         rescue CI::Queue::Redis::LostMaster
           false
         end

--- a/ruby/lib/ci/queue/redis/supervisor.rb
+++ b/ruby/lib/ci/queue/redis/supervisor.rb
@@ -22,13 +22,13 @@ module CI
           yield if block_given?
 
           time_left = config.timeout
-          until exhausted? || time_left <= 0
+          until exhausted? || time_left <= 0 || build.max_visible_failures_reached?
             sleep 1
             time_left -= 1
 
             yield if block_given?
           end
-          exhausted?
+          exhausted? || build.max_visible_failures_reached?
         rescue CI::Queue::Redis::LostMaster
           false
         end

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -45,7 +45,7 @@ module CI
 
         def poll
           wait_for_master
-          until shutdown_required? || config.circuit_breakers.any?(&:open?) || exhausted?
+          until shutdown_required? || config.circuit_breakers.any?(&:open?) || exhausted? || build.max_visible_failures_reached?
             if test = reserve
               yield index.fetch(test), @last_warning
             else

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -45,7 +45,7 @@ module CI
 
         def poll
           wait_for_master
-          until shutdown_required? || config.circuit_breakers.any?(&:open?) || exhausted? || build.max_visible_failures_reached?
+          until shutdown_required? || config.circuit_breakers.any?(&:open?) || exhausted? || max_test_failed?
             if test = reserve
               yield index.fetch(test), @last_warning
             else

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -50,7 +50,7 @@ module CI
       end
 
       def poll
-        while config.circuit_breakers.none?(&:open?) && !max_visible_failures_reached? && test = @queue.shift
+        while config.circuit_breakers.none?(&:open?) && !max_test_failed? && test = @queue.shift
           yield index.fetch(test)
         end
       end
@@ -64,18 +64,18 @@ module CI
         true
       end
 
-      def increment_visible_failures
-        @visible_failures = visible_failures + 1
+      def increment_test_failed
+        @test_failed = test_failed + 1
       end
 
-      def visible_failures
-        @visible_failures ||= 0
+      def test_failed
+        @test_failed ||= 0
       end
 
-      def max_visible_failures_reached?
-        return false if config.max_visible_tests.nil?
+      def max_test_failed?
+        return false if config.max_test_failed.nil?
 
-        visible_failures >= config.max_visible_tests
+        test_failed >= config.max_test_failed
       end
 
       def requeue(test)

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -153,6 +153,10 @@ module Minitest
         if queue.config.circuit_breakers.any?(&:open?)
           STDERR.puts queue.config.circuit_breakers.map(&:message).join(' ').strip
         end
+
+        if queue.max_test_failed?
+          STDERR.puts 'This worker is exiting early because too many failed tests were encountered.'
+        end
       else
         super
       end
@@ -186,7 +190,7 @@ module Minitest
         end
 
         if !requeued && failed
-          queue.increment_visible_failures
+          queue.increment_test_failed
         end
       end
     end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -174,13 +174,19 @@ module Minitest
           queue.report_success!
         end
 
+        requeued = false
         if failed && queue.requeue(example)
+          requeued = true
           result.requeue!
           reporter.record(result)
         elsif queue.acknowledge(example) || !failed
           # If the test was already acknowledged by another worker (we timed out)
           # Then we only record it if it is successful.
           reporter.record(result)
+        end
+
+        if !requeued && failed
+          queue.increment_visible_failures
         end
       end
     end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -181,7 +181,12 @@ module Minitest
           end
 
           unless supervisor.exhausted?
-            abort! "#{supervisor.size} tests weren't run."
+            msg = "#{supervisor.size} tests weren't run."
+            if supervisor.build.max_visible_failures_reached?
+              puts (msg)
+            else
+              abort!(msg)
+            end
           end
         end
 
@@ -397,6 +402,15 @@ module Minitest
           opts.separator ""
           opts.on('--max-duration SECONDS', Integer, help) do |max|
             queue_config.max_duration = max
+          end
+
+          help = <<~EOS
+            Defines how many user visible tests can be fail.
+            Defaults to none.
+          EOS
+          opts.separator ""
+          opts.on('--max-visible-tests MAX', Integer, help) do |max|
+            queue_config.max_visible_tests = max
           end
 
           help = <<~EOS

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -182,8 +182,9 @@ module Minitest
 
           unless supervisor.exhausted?
             msg = "#{supervisor.size} tests weren't run."
-            if supervisor.build.max_visible_failures_reached?
-              puts (msg)
+            if supervisor.max_test_failed?
+              puts('Encountered too many failed tests. Test run was ended early.')
+              puts(msg)
             else
               abort!(msg)
             end
@@ -405,12 +406,12 @@ module Minitest
           end
 
           help = <<~EOS
-            Defines how many user visible tests can be fail.
+            Defines how many user test tests can be fail.
             Defaults to none.
           EOS
           opts.separator ""
-          opts.on('--max-visible-tests MAX', Integer, help) do |max|
-            queue_config.max_visible_tests = max
+          opts.on('--max-test-failed MAX', Integer, help) do |max|
+            queue_config.max_test_failed = max
           end
 
           help = <<~EOS


### PR DESCRIPTION
This PR adds a feature to CI-Queue that allows us to short circuit the test workers and summary step. If a build encounters many test failures, then the probability is hight that most of those tests originate from a similar failure source. Short-circuiting test runs in case we have many test failures that allow us to give developers faster feedback and reduce the load on our CI system.

integration build: https://buildkite.com/shopify/shopify-selective-tests/builds/139838