### PR TITLE
Test and fix deprecation on Ruby 2.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,15 @@ jobs:
         ports:
           - 6379:6379
 
+    strategy:
+      matrix:
+        ruby: [ '2.6', '2.7' ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby 2.6.x
+      - name: Set up Ruby ${{ matrix.ruby }}
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: ${{ matrix.ruby }}
       - name: Run Ruby tests
         run: |
           bin/before-install

--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ansi'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', "~> 10.0"
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'redis', '~> 3.3'

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -2,11 +2,12 @@
 module CI
   module Queue
     class Configuration
-      attr_accessor :timeout, :build_id, :worker_id, :max_requeues, :grind_count, :failure_file
-      attr_accessor :requeue_tolerance, :namespace, :seed, :failing_test, :statsd_endpoint
+      attr_accessor :timeout, :worker_id, :max_requeues, :grind_count, :failure_file
+      attr_accessor :requeue_tolerance, :namespace, :failing_test, :statsd_endpoint
       attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
       attr_accessor :max_test_failed
       attr_reader :circuit_breakers
+      attr_writer :seed, :build_id
 
       class << self
         def from_env(env)

--- a/ruby/lib/ci/queue/output_helpers.rb
+++ b/ruby/lib/ci/queue/output_helpers.rb
@@ -8,8 +8,8 @@ module CI
 
       private
 
-      def step(*args)
-        ci_provider.step(*args)
+      def step(*args, **kwargs)
+        ci_provider.step(*args, **kwargs)
       end
 
       def reopen_previous_step

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -15,6 +15,7 @@ module CI
         attr_reader :total
 
         def initialize(redis, config)
+          @last_warning = nil
           @reserved_test = nil
           @shutdown_required = false
           super(redis, config)

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -88,6 +88,7 @@ module Minitest
     end
 
     def flaked?
+      @flaky ||= false
       !!((Flaked === failure) || @flaky)
     end
 

--- a/ruby/lib/minitest/queue/statsd.rb
+++ b/ruby/lib/minitest/queue/statsd.rb
@@ -19,7 +19,7 @@ module Minitest
           @socket = UDPSocket.new
           @socket.connect(host, Integer(port))
         end
-      rescue SocketError => e
+      rescue SocketError
         # No-op, we shouldn't fail CI because of statsd
       end
 

--- a/ruby/test/ci/queue/redis_test.rb
+++ b/ruby/test/ci/queue/redis_test.rb
@@ -42,15 +42,15 @@ class CI::Queue::RedisTest < Minitest::Test
   end
 
   def test_retry_queue_with_all_tests_passing
-    test_order = poll(@queue)
+    poll(@queue)
     retry_queue = @queue.retry_queue
     populate(retry_queue)
     retry_test_order = poll(retry_queue)
     assert_equal [], retry_test_order
   end
 
-  def test_retry_queue_with_all_tests_passing
-    test_order = poll(@queue)
+  def test_retry_queue_with_all_tests_passing_2
+    poll(@queue)
     retry_queue = @queue.retry_queue
     populate(retry_queue)
     retry_test_order = poll(retry_queue) do |test|

--- a/ruby/test/support/reporter_test_helper.rb
+++ b/ruby/test/support/reporter_test_helper.rb
@@ -2,8 +2,8 @@
 module ReporterTestHelper
   private
 
-  def result(*args)
-    result = runnable(*args)
+  def result(*args, **kwargs)
+    result = runnable(*args, **kwargs)
     if defined? Minitest::Result
       result = Minitest::Result.from(result)
     end


### PR DESCRIPTION
As the title says.

Also since I upgraded rake, it now run tests with extra verbosity by default which led to more warning fixes, such as initialized instance variables etc.