### PR TITLE
Get rid of the dependency on the ansi gem

### DIFF
--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -29,8 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  spec.add_dependency 'ansi'
-
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')

--- a/ruby/lib/ci/queue/output_helpers.rb
+++ b/ruby/lib/ci/queue/output_helpers.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
-require 'ansi'
-
 module CI
   module Queue
     module OutputHelpers
-      include ANSI::Code
-
       private
 
       def step(*args, **kwargs)
@@ -26,6 +22,22 @@ module CI
         else
           DefaultOutput
         end
+      end
+
+      def red(text)
+        colorize(text, 31)
+      end
+
+      def green(text)
+        colorize(text, 32)
+      end
+
+      def yellow(text)
+        colorize(text, 33)
+      end
+
+      def colorize(text, color_code)
+        "\e[#{color_code}m#{text}\e[0m"
       end
 
       module DefaultOutput

--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 require 'delegate'
-require 'ansi'
+require 'ci/queue/output_helpers'
 
 module Minitest
   module Queue
     class FailureFormatter < SimpleDelegator
-      include ANSI::Code
+      include ::CI::Queue::OutputHelpers
 
       def initialize(test)
         @test = test


### PR DESCRIPTION
Since it's the last thing throwing warnings, I figured we should reconsider it. 

For most people these warnings don't matter, but if you are trying to run your test suite with ruby on verbose mode, it's annoying to have warnings coming out of your test runner...

We're only using a terribly small portion of it, it can easily be replaced by a dozen lines of very simple code. I think we can 🔥 it.