### PR TITLE
Add CI::Queue.requeueable to define wether a failure should be requeued

### DIFF
--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -18,10 +18,14 @@ module CI
   module Queue
     extend self
 
-    attr_accessor :shuffler
+    attr_accessor :shuffler, :requeueable
 
     module Warnings
       RESERVED_LOST_TEST = :RESERVED_LOST_TEST
+    end
+
+    def requeueable?(test_result)
+      requeueable.nil? || requeueable.call(test_result)
     end
 
     def shuffle(tests, random)

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -180,7 +180,7 @@ module Minitest
         end
 
         requeued = false
-        if failed && queue.requeue(example)
+        if failed && CI::Queue.requeueable?(result) && queue.requeue(example)
           requeued = true
           result.requeue!
           reporter.record(result)

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -211,7 +211,7 @@ module RSpec
             reporter.report_success!
           end
 
-          if @exception && reporter.requeue
+          if @exception && CI::Queue.requeueable?(@exception) && reporter.requeue
             reporter.cancel_run!
             dup.mark_as_requeued!(reporter)
             return true

--- a/ruby/test/fixtures/test/custom_requeue_test.rb
+++ b/ruby/test/fixtures/test/custom_requeue_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+CI::Queue.requeueable = -> (result) do
+  !result.failures.any? do |failure|
+    failure.error.is_a?(TypeError)
+  end
+end
+
+class ATest < Minitest::Test
+  def test_requeue_allowed
+    1 + '1' # TypeError
+  end
+
+  def test_requeue_disallowed
+    1.bar # NoMethodError
+  end
+end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -43,6 +43,29 @@ module Integration
       assert_equal '--- Ran 11 tests, 8 assertions, 2 failures, 1 errors, 1 skips, 4 requeues in X.XXs', output
     end
 
+    def test_custom_requeue
+      out, err = capture_subprocess_io do
+        system(
+          { 'BUILDKITE' => '1' },
+          @exe, 'run',
+          '--queue', @redis_url,
+          '--seed', 'foobar',
+          '--build', '1',
+          '--worker', '1',
+          '--timeout', '1',
+          '--max-requeues', '1',
+          '--requeue-tolerance', '1',
+          '-Itest',
+          'test/custom_requeue_test.rb',
+          chdir: 'test/fixtures/',
+        )
+      end
+
+      assert_empty err
+      output = normalize(out.lines.last.strip)
+      assert_equal '--- Ran 3 tests, 0 assertions, 0 failures, 2 errors, 0 skips, 1 requeues in X.XXs', output
+    end
+
     def test_max_test_failed
       out, err = capture_subprocess_io do
         system(


### PR DESCRIPTION
For context I'm using https://github.com/Shopify/deprecation_toolkit to fix Ruby 2.7 keyword argument warnings. The problem is that Ruby only fire these warnings once, so they have a significant false nagative change if they are retried.

But even beyond this, I think it's an useful API, we could probably have other uses for it.

Thoughts?