### PR TITLE
Rewrite JunitReporter.

### DIFF
--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -418,58 +418,64 @@ module Integration
       output = normalize(out.lines.last.strip)
       assert_equal 'Ran 9 tests, 6 assertions, 1 failures, 1 errors, 1 skips, 2 requeues in X.XXs', output
 
-      assert_equal strip_heredoc(<<-END), normalize_xml(File.read(@junit_path))
-       <?xml version="1.0" encoding="UTF-8"?>
-       <testsuites>
-         <testsuite name="ATest" filepath="test/dummy_test.rb" skipped="5" failures="1" errors="0" tests="6" assertions="5" time="X.XX">
-           <testcase name="test_foo" lineno="5" classname="ATest" assertions="0" time="X.XX" flaky_test="false">
-           <skipped type="Minitest::Skip"/>
-           </testcase>
-           <testcase name="test_bar" lineno="9" classname="ATest" assertions="1" time="X.XX" flaky_test="false">
-           <skipped type="Minitest::Assertion"/>
-           </testcase>
-           <testcase name="test_flaky" lineno="13" classname="ATest" assertions="1" time="X.XX" flaky_test="true">
-           <failure type="Minitest::Assertion" message="Expected false to be truthy.">
-       Skipped:
-       test_flaky(ATest) [./test/fixtures/test/dummy_test.rb:18]:
-       Expected false to be truthy.
-           </failure>
-           </testcase>
-           <testcase name="test_flaky_passes" lineno="26" classname="ATest" assertions="1" time="X.XX" flaky_test="true">
-           </testcase>
-           <testcase name="test_flaky_fails_retry" lineno="22" classname="ATest" assertions="1" time="X.XX" flaky_test="true">
-           <failure type="Minitest::Assertion" message="Expected false to be truthy.">
-       Skipped:
-       test_flaky_fails_retry(ATest) [./test/fixtures/test/dummy_test.rb:23]:
-       Expected false to be truthy.
-           </failure>
-           </testcase>
-           <testcase name="test_bar" lineno="9" classname="ATest" assertions="1" time="X.XX" flaky_test="false">
-           <failure type="Minitest::Assertion" message="Expected false to be truthy.">
-       Failure:
-       test_bar(ATest) [./test/fixtures/test/dummy_test.rb:10]:
-       Expected false to be truthy.
-           </failure>
-           </testcase>
-         </testsuite>
-         <testsuite name="BTest" filepath="test/dummy_test.rb" skipped="1" failures="0" errors="1" tests="3" assertions="1" time="X.XX">
-           <testcase name="test_bar" lineno="36" classname="BTest" assertions="0" time="X.XX" flaky_test="false">
-           <skipped type="TypeError"/>
-           </testcase>
-           <testcase name="test_foo" lineno="32" classname="BTest" assertions="1" time="X.XX" flaky_test="false">
-           </testcase>
-           <testcase name="test_bar" lineno="36" classname="BTest" assertions="0" time="X.XX" flaky_test="false">
-           <error type="TypeError" message="TypeError: String can't be coerced into Integer...">
-       Failure:
-       test_bar(BTest) [./test/fixtures/test/dummy_test.rb:37]:
-       TypeError: String can't be coerced into Integer
-           ./test/fixtures/test/dummy_test.rb:37:in `+'
-           ./test/fixtures/test/dummy_test.rb:37:in `test_bar'
-           </error>
-           </testcase>
-         </testsuite>
-       </testsuites>
-      END
+      assert_equal <<~XML, normalize_xml(File.read(@junit_path))
+        <?xml version='1.0' encoding='UTF-8'?>
+        <testsuites>
+          <testsuite name='ATest' filepath='test/dummy_test.rb' skipped='5' failures='1' errors='0' tests='6' assertions='5' time='X.XX'>
+            <testcase name='test_foo' classname='ATest' assertions='0' time='X.XX' flaky_test='false' lineno='5'>
+              <skipped type='Minitest::Skip'/>
+            </testcase>
+            <testcase name='test_bar' classname='ATest' assertions='1' time='X.XX' flaky_test='false' lineno='5'>
+              <skipped type='Minitest::Assertion'/>
+            </testcase>
+            <testcase name='test_flaky' classname='ATest' assertions='1' time='X.XX' flaky_test='true' lineno='5'>
+              <failure type='Minitest::Assertion' message='Expected false to be truthy.'>
+                <![CDATA[
+        Skipped:
+        test_flaky(ATest) [./test/fixtures/test/dummy_test.rb:18]:
+        Expected false to be truthy.
+        ]]>
+              </failure>
+            </testcase>
+            <testcase name='test_flaky_passes' classname='ATest' assertions='1' time='X.XX' flaky_test='true' lineno='5'/>
+            <testcase name='test_flaky_fails_retry' classname='ATest' assertions='1' time='X.XX' flaky_test='true' lineno='5'>
+              <failure type='Minitest::Assertion' message='Expected false to be truthy.'>
+                <![CDATA[
+        Skipped:
+        test_flaky_fails_retry(ATest) [./test/fixtures/test/dummy_test.rb:23]:
+        Expected false to be truthy.
+        ]]>
+              </failure>
+            </testcase>
+            <testcase name='test_bar' classname='ATest' assertions='1' time='X.XX' flaky_test='false' lineno='5'>
+              <failure type='Minitest::Assertion' message='Expected false to be truthy.'>
+                <![CDATA[
+        Failure:
+        test_bar(ATest) [./test/fixtures/test/dummy_test.rb:10]:
+        Expected false to be truthy.
+        ]]>
+              </failure>
+            </testcase>
+          </testsuite>
+          <testsuite name='BTest' filepath='test/dummy_test.rb' skipped='1' failures='0' errors='1' tests='3' assertions='1' time='X.XX'>
+            <testcase name='test_bar' classname='BTest' assertions='0' time='X.XX' flaky_test='false' lineno='36'>
+              <skipped type='TypeError'/>
+            </testcase>
+            <testcase name='test_foo' classname='BTest' assertions='1' time='X.XX' flaky_test='false' lineno='36'/>
+            <testcase name='test_bar' classname='BTest' assertions='0' time='X.XX' flaky_test='false' lineno='36'>
+              <error type='TypeError' message='TypeError: String can&apos;t be coerced into Integer'>
+                <![CDATA[
+        Failure:
+        test_bar(BTest) [./test/fixtures/test/dummy_test.rb:37]:
+        TypeError: String can't be coerced into Integer
+            ./test/fixtures/test/dummy_test.rb:37:in `+'
+            ./test/fixtures/test/dummy_test.rb:37:in `test_bar'
+        ]]>
+              </error>
+            </testcase>
+          </testsuite>
+        </testsuites>
+      XML
     end
 
     def test_redis_reporter_failure_file
@@ -603,7 +609,7 @@ module Integration
 
       assert_empty err
       output = normalize(out)
-      assert_equal strip_heredoc(<<-END), output
+      assert_equal <<~END, output
         Ran 1 tests, 1 assertions, 1 failures, 0 errors, 0 skips, 0 requeues in X.XXs
       END
     end

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'minitest/reporters/junit_reporter'
+
+module Minitest::Reporters
+  class JUnitReporterTest < Minitest::Test
+    include ReporterTestHelper
+
+    def setup
+      @reporter = Minitest::Queue::JUnitReporter.new
+    end
+
+    def test_generate_junitxml_for_passing_tests
+      @reporter.record(result('test_foo'))
+      @reporter.record(result('test_bar'))
+
+      assert_equal <<~XML, generate_xml(@reporter)
+        <?xml version='1.0' encoding='UTF-8'?>
+        <testsuites>
+          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='0' errors='0' tests='2' assertions='2' time='0.24'>
+            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'/>
+            <testcase name='test_bar' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'/>
+          </testsuite>
+        </testsuites>
+      XML
+    end
+
+    def test_generate_junitxml_for_failing_test
+      @reporter.record(result('test_foo', failure: 'Assertion failed'))
+
+      assert_equal <<~XML, generate_xml(@reporter)
+        <?xml version='1.0' encoding='UTF-8'?>
+        <testsuites>
+          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='1' errors='0' tests='1' assertions='1' time='0.12'>
+            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
+              <failure type='Minitest::Assertion' message='Assertion failed'>
+                <![CDATA[
+        Failure:
+        test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
+        Assertion failed
+        ]]>
+              </failure>
+            </testcase>
+          </testsuite>
+        </testsuites>
+      XML
+    end
+
+    def test_generate_junitxml_with_ansi_codes_in_message
+      @reporter.record(result('test_foo', failure: "\e[31mAssertion failed\e[0m"))
+
+      assert_equal <<~XML, generate_xml(@reporter)
+        <?xml version='1.0' encoding='UTF-8'?>
+        <testsuites>
+          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='1' errors='0' tests='1' assertions='1' time='0.12'>
+            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
+              <failure type='Minitest::Assertion' message='Assertion failed'>
+                <![CDATA[
+        Failure:
+        test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
+        \e[31mAssertion failed\e[0m
+        ]]>
+              </failure>
+            </testcase>
+          </testsuite>
+        </testsuites>
+      XML
+    end
+
+    def test_generate_junitxml_for_skipped_test
+      @reporter.record(result('test_foo', skipped: true))
+
+      assert_equal <<~XML, generate_xml(@reporter)
+        <?xml version='1.0' encoding='UTF-8'?>
+        <testsuites>
+          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='1' failures='0' errors='0' tests='1' assertions='1' time='0.12'>
+            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
+              <skipped type='Minitest::Skip'/>
+            </testcase>
+          </testsuite>
+        </testsuites>
+      XML
+    end
+
+    def test_generate_junitxml_for_errored_test
+      @reporter.record(result('test_foo', unexpected_error: true))
+
+      assert_equal <<~XML, generate_xml(@reporter)
+        <?xml version='1.0' encoding='UTF-8'?>
+        <testsuites>
+          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='0' errors='1' tests='1' assertions='1' time='0.12'>
+            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
+              <error type='StandardError' message='StandardError: StandardError'>
+                <![CDATA[
+        Failure:
+        test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
+        StandardError: StandardError
+            #{Dir.pwd}/test/support/reporter_test_helper.rb:15:in `runnable'
+            #{Dir.pwd}/test/support/reporter_test_helper.rb:6:in `result'
+            #{Dir.pwd}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'
+        ]]>
+              </error>
+            </testcase>
+          </testsuite>
+        </testsuites>
+      XML
+    end
+
+    def test_generate_junitxml_for_requeued_test
+      @reporter.record(result('test_foo', requeued: true))
+
+      assert_equal <<~XML, generate_xml(@reporter)
+        <?xml version='1.0' encoding='UTF-8'?>
+        <testsuites>
+          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='1' failures='0' errors='0' tests='1' assertions='1' time='0.12'>
+            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
+              <skipped type='Minitest::Assertion'/>
+            </testcase>
+          </testsuite>
+        </testsuites>
+      XML
+    end
+
+    private
+
+    def generate_xml(junitxml)
+      io = StringIO.new
+      junitxml.format_document(junitxml.generate_document, io)
+      io.string
+    end
+  end
+end

--- a/ruby/test/support/output_test_helpers.rb
+++ b/ruby/test/support/output_test_helpers.rb
@@ -29,7 +29,7 @@ module OutputTestHelpers
   end
 
   def freeze_xml_timing(output)
-    output.gsub(/time="[\d\-\.e]+"/, 'time="X.XX"')
+    output.gsub(/time='[\d\-\.e]+'/, "time='X.XX'")
   end
 
   def normalize(output)

--- a/ruby/test/support/reporter_test_helper.rb
+++ b/ruby/test/support/reporter_test_helper.rb
@@ -2,21 +2,42 @@
 module ReporterTestHelper
   private
 
-  def result(*args, **kwargs)
-    result = runnable(*args, **kwargs)
-    if defined? Minitest::Result
-      result = Minitest::Result.from(result)
-    end
+  def result(name, **kwargs)
+    result = Minitest::Result.from(runnable(name, **kwargs))
+    result.source_location = ["test/my_test.rb", 12]
     result
   end
 
   def runnable(name, failure: nil, requeued: false, skipped: false, unexpected_error: false)
     runnable = Minitest::Test.new(name)
-    runnable.failures << failure if failure
+    runnable.failures << generate_assertion(failure) if failure
     runnable.failures << MiniTest::Skip.new if skipped
-    runnable.failures << Minitest::UnexpectedError.new(StandardError.new) if unexpected_error
-    runnable.failures << MiniTest::Requeue.new('Failed') if requeued
+    runnable.failures << generate_unexpected_error if unexpected_error
+    runnable.failures << MiniTest::Requeue.new(generate_assertion("Failed")) if requeued
     runnable.assertions += 1
+    runnable.time = 0.12
     runnable
+  end
+
+  def generate_unexpected_error
+    error = StandardError.new
+    error.set_backtrace([
+      "#{Dir.pwd}/test/support/reporter_test_helper.rb:15:in `runnable'",
+      "#{Dir.pwd}/test/support/reporter_test_helper.rb:6:in `result'",
+      "#{Dir.pwd}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
+    ])
+    Minitest::UnexpectedError.new(error)
+  end
+
+  def generate_assertion(message)
+    return message if message.is_a?(Minitest::Assertion)
+
+    error = Minitest::Assertion.new(message)
+    error.set_backtrace([
+      "#{Dir.pwd}/test/support/reporter_test_helper.rb:15:in `runnable'",
+      "#{Dir.pwd}/test/support/reporter_test_helper.rb:6:in `result'",
+      "#{Dir.pwd}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
+    ])
+    error
   end
 end


### PR DESCRIPTION
- Use REXML rather than Builder. Slightly more verbose, but doesn’t turn escape codes into garbage. Also means that we can potentially get rid of a dependency that is no longer maintained.
- Wrap output in CDATA sections so we don’t have to format it according to XML’s rules. We will have to adjust our JUnitXML parser accordingly, because it's currently not handling CDATA sections.
- Add unit tests.