### PR TITLE
Generate XML 1.1 JUnit documents so we can use control characters.

### DIFF
--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -16,7 +16,12 @@ module Minitest
       def generate_document
         suites = tests.group_by { |test| test.klass }
 
-        doc = REXML::Document.new
+        doc = REXML::Document.new(nil, {
+          :prologue_quote => :quote,
+          :attribute_quote => :quote,
+        })
+        doc << REXML::XMLDecl.new('1.1', 'utf-8')
+
         testsuites = doc.add_element('testsuites')
         suites.each do |suite, tests|
           add_tests_to(testsuites, suite, tests)
@@ -25,7 +30,6 @@ module Minitest
       end
 
       def format_document(doc, io)
-        io << "<?xml version='1.0' encoding='UTF-8'?>\n"
         formatter = REXML::Formatters::Pretty.new
         formatter.write(doc, io)
         io << "\n"

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -419,17 +419,17 @@ module Integration
       assert_equal 'Ran 9 tests, 6 assertions, 1 failures, 1 errors, 1 skips, 2 requeues in X.XXs', output
 
       assert_equal <<~XML, normalize_xml(File.read(@junit_path))
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
-          <testsuite name='ATest' filepath='test/dummy_test.rb' skipped='5' failures='1' errors='0' tests='6' assertions='5' time='X.XX'>
-            <testcase name='test_foo' classname='ATest' assertions='0' time='X.XX' flaky_test='false' lineno='5'>
-              <skipped type='Minitest::Skip'/>
+          <testsuite name="ATest" filepath="test/dummy_test.rb" skipped="5" failures="1" errors="0" tests="6" assertions="5" time="X.XX">
+            <testcase name="test_foo" classname="ATest" assertions="0" time="X.XX" flaky_test="false" lineno="5">
+              <skipped type="Minitest::Skip"/>
             </testcase>
-            <testcase name='test_bar' classname='ATest' assertions='1' time='X.XX' flaky_test='false' lineno='5'>
-              <skipped type='Minitest::Assertion'/>
+            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" lineno="5">
+              <skipped type="Minitest::Assertion"/>
             </testcase>
-            <testcase name='test_flaky' classname='ATest' assertions='1' time='X.XX' flaky_test='true' lineno='5'>
-              <failure type='Minitest::Assertion' message='Expected false to be truthy.'>
+            <testcase name="test_flaky" classname="ATest" assertions="1" time="X.XX" flaky_test="true" lineno="5">
+              <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Skipped:
         test_flaky(ATest) [./test/fixtures/test/dummy_test.rb:18]:
@@ -437,9 +437,9 @@ module Integration
         ]]>
               </failure>
             </testcase>
-            <testcase name='test_flaky_passes' classname='ATest' assertions='1' time='X.XX' flaky_test='true' lineno='5'/>
-            <testcase name='test_flaky_fails_retry' classname='ATest' assertions='1' time='X.XX' flaky_test='true' lineno='5'>
-              <failure type='Minitest::Assertion' message='Expected false to be truthy.'>
+            <testcase name="test_flaky_passes" classname="ATest" assertions="1" time="X.XX" flaky_test="true" lineno="5"/>
+            <testcase name="test_flaky_fails_retry" classname="ATest" assertions="1" time="X.XX" flaky_test="true" lineno="5">
+              <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Skipped:
         test_flaky_fails_retry(ATest) [./test/fixtures/test/dummy_test.rb:23]:
@@ -447,8 +447,8 @@ module Integration
         ]]>
               </failure>
             </testcase>
-            <testcase name='test_bar' classname='ATest' assertions='1' time='X.XX' flaky_test='false' lineno='5'>
-              <failure type='Minitest::Assertion' message='Expected false to be truthy.'>
+            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" lineno="5">
+              <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Failure:
         test_bar(ATest) [./test/fixtures/test/dummy_test.rb:10]:
@@ -457,13 +457,13 @@ module Integration
               </failure>
             </testcase>
           </testsuite>
-          <testsuite name='BTest' filepath='test/dummy_test.rb' skipped='1' failures='0' errors='1' tests='3' assertions='1' time='X.XX'>
-            <testcase name='test_bar' classname='BTest' assertions='0' time='X.XX' flaky_test='false' lineno='36'>
-              <skipped type='TypeError'/>
+          <testsuite name="BTest" filepath="test/dummy_test.rb" skipped="1" failures="0" errors="1" tests="3" assertions="1" time="X.XX">
+            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" lineno="36">
+              <skipped type="TypeError"/>
             </testcase>
-            <testcase name='test_foo' classname='BTest' assertions='1' time='X.XX' flaky_test='false' lineno='36'/>
-            <testcase name='test_bar' classname='BTest' assertions='0' time='X.XX' flaky_test='false' lineno='36'>
-              <error type='TypeError' message='TypeError: String can&apos;t be coerced into Integer'>
+            <testcase name="test_foo" classname="BTest" assertions="1" time="X.XX" flaky_test="false" lineno="36"/>
+            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" lineno="36">
+              <error type="TypeError" message="TypeError: String can&apos;t be coerced into Integer">
                 <![CDATA[
         Failure:
         test_bar(BTest) [./test/fixtures/test/dummy_test.rb:37]:

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'minitest/reporters/junit_reporter'
+require "test_helper"
+require "minitest/reporters/junit_reporter"
 
 module Minitest::Reporters
   class JUnitReporterTest < Minitest::Test
@@ -11,29 +11,29 @@ module Minitest::Reporters
     end
 
     def test_generate_junitxml_for_passing_tests
-      @reporter.record(result('test_foo'))
-      @reporter.record(result('test_bar'))
+      @reporter.record(result("test_foo"))
+      @reporter.record(result("test_bar"))
 
       assert_equal <<~XML, generate_xml(@reporter)
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
-          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='0' errors='0' tests='2' assertions='2' time='0.24'>
-            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'/>
-            <testcase name='test_bar' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'/>
+          <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="0" errors="0" tests="2" assertions="2" time="0.24">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12"/>
+            <testcase name="test_bar" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12"/>
           </testsuite>
         </testsuites>
       XML
     end
 
     def test_generate_junitxml_for_failing_test
-      @reporter.record(result('test_foo', failure: 'Assertion failed'))
+      @reporter.record(result("test_foo", failure: "Assertion failed"))
 
       assert_equal <<~XML, generate_xml(@reporter)
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
-          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='1' errors='0' tests='1' assertions='1' time='0.12'>
-            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
-              <failure type='Minitest::Assertion' message='Assertion failed'>
+          <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="1" errors="0" tests="1" assertions="1" time="0.12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+              <failure type="Minitest::Assertion" message="Assertion failed">
                 <![CDATA[
         Failure:
         test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
@@ -47,14 +47,14 @@ module Minitest::Reporters
     end
 
     def test_generate_junitxml_with_ansi_codes_in_message
-      @reporter.record(result('test_foo', failure: "\e[31mAssertion failed\e[0m"))
+      @reporter.record(result("test_foo", failure: "\e[31mAssertion failed\e[0m"))
 
       assert_equal <<~XML, generate_xml(@reporter)
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
-          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='1' errors='0' tests='1' assertions='1' time='0.12'>
-            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
-              <failure type='Minitest::Assertion' message='Assertion failed'>
+          <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="1" errors="0" tests="1" assertions="1" time="0.12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+              <failure type="Minitest::Assertion" message="Assertion failed">
                 <![CDATA[
         Failure:
         test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
@@ -68,14 +68,14 @@ module Minitest::Reporters
     end
 
     def test_generate_junitxml_for_skipped_test
-      @reporter.record(result('test_foo', skipped: true))
+      @reporter.record(result("test_foo", skipped: true))
 
       assert_equal <<~XML, generate_xml(@reporter)
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
-          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='1' failures='0' errors='0' tests='1' assertions='1' time='0.12'>
-            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
-              <skipped type='Minitest::Skip'/>
+          <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+              <skipped type="Minitest::Skip"/>
             </testcase>
           </testsuite>
         </testsuites>
@@ -83,14 +83,14 @@ module Minitest::Reporters
     end
 
     def test_generate_junitxml_for_errored_test
-      @reporter.record(result('test_foo', unexpected_error: true))
+      @reporter.record(result("test_foo", unexpected_error: true))
 
       assert_equal <<~XML, generate_xml(@reporter)
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
-          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='0' failures='0' errors='1' tests='1' assertions='1' time='0.12'>
-            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
-              <error type='StandardError' message='StandardError: StandardError'>
+          <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="0" errors="1" tests="1" assertions="1" time="0.12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+              <error type="StandardError" message="StandardError: StandardError">
                 <![CDATA[
         Failure:
         test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
@@ -107,14 +107,14 @@ module Minitest::Reporters
     end
 
     def test_generate_junitxml_for_requeued_test
-      @reporter.record(result('test_foo', requeued: true))
+      @reporter.record(result("test_foo", requeued: true))
 
       assert_equal <<~XML, generate_xml(@reporter)
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
-          <testsuite name='Minitest::Test' filepath='test/my_test.rb' skipped='1' failures='0' errors='0' tests='1' assertions='1' time='0.12'>
-            <testcase name='test_foo' classname='Minitest::Test' assertions='1' time='0.12' flaky_test='false' lineno='12'>
-              <skipped type='Minitest::Assertion'/>
+          <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+              <skipped type="Minitest::Assertion"/>
             </testcase>
           </testsuite>
         </testsuites>

--- a/ruby/test/support/output_test_helpers.rb
+++ b/ruby/test/support/output_test_helpers.rb
@@ -29,7 +29,7 @@ module OutputTestHelpers
   end
 
   def freeze_xml_timing(output)
-    output.gsub(/time='[\d\-\.e]+'/, "time='X.XX'")
+    output.gsub(/time="[\d\-\.e]+"/, 'time="X.XX"')
   end
 
   def normalize(output)


### PR DESCRIPTION
Turns out that XML 1.0 does not (officially) support control characters, like `\e`. The JUnit XML files we generate often include escape characters because we use ANSI color codes in our assertion messages. 

XML 1.1 adds support for these characters. Our parsers are fine with using `\e`, and can use both versions, so this is PR is to make things "technically correct".

At the same time, I've also updated the generator to use double quotes, which I find more pleasant to look at.

