### PR TITLE
Revert "Revert "Clean up some old backwards compatibility code that we can get rid off""

### DIFF
--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')
+  spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.12')
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'redis', '~> 3.3'
   spec.add_development_dependency 'simplecov', '~> 0.12'

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -198,22 +198,6 @@ module Minitest
   end
 end
 
-MiniTest.singleton_class.prepend(MiniTest::Queue)
-if defined? MiniTest::Result
-  MiniTest::Result.prepend(MiniTest::Requeueing)
-  MiniTest::Result.prepend(MiniTest::Flakiness)
-else
-  MiniTest::Test.prepend(MiniTest::Requeueing)
-  MiniTest::Test.prepend(MiniTest::Flakiness)
-
-  module MinitestBackwardCompatibility
-    def source_location
-      method(name).source_location
-    end
-
-    def klass
-      self.class.name
-    end
-  end
-  MiniTest::Test.prepend(MinitestBackwardCompatibility)
-end
+Minitest.singleton_class.prepend(Minitest::Queue)
+Minitest::Result.prepend(Minitest::Requeueing)
+Minitest::Result.prepend(Minitest::Flakiness)

--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -52,7 +52,7 @@ module Minitest
 
       def body
         error = test.failure
-        message = if error.is_a?(MiniTest::UnexpectedError)
+        message = if error.is_a?(Minitest::UnexpectedError)
           "#{error.exception.class}: #{error.exception.message}"
         else
           error.exception.message

--- a/ruby/test/minitest/queue/test_time_recorder_test.rb
+++ b/ruby/test/minitest/queue/test_time_recorder_test.rb
@@ -21,7 +21,7 @@ module Minitest::Queue
     end
 
     def test_record_when_test_pass
-      test = MiniTest::Mock.new
+      test = Minitest::Mock.new
       test.expect(:passed?, true)
       test.expect(:name, 'some test')
       test.expect(:time, 0.1) # in seconds
@@ -33,7 +33,7 @@ module Minitest::Queue
     end
 
     def test_record_do_nothing_when_test_failed
-      test = MiniTest::Mock.new
+      test = Minitest::Mock.new
       test.expect(:passed?, false)
       @test_time_recorder.record(test)
 

--- a/ruby/test/minitest/queue/test_time_reporter_test.rb
+++ b/ruby/test/minitest/queue/test_time_reporter_test.rb
@@ -58,7 +58,7 @@ module Minitest
       private
 
       def mock_build(test_time_hash)
-        build = MiniTest::Mock.new
+        build = Minitest::Mock.new
         build.expect(:fetch, test_time_hash)
         build
       end

--- a/ruby/test/support/reporter_test_helper.rb
+++ b/ruby/test/support/reporter_test_helper.rb
@@ -11,9 +11,9 @@ module ReporterTestHelper
   def runnable(name, failure: nil, requeued: false, skipped: false, unexpected_error: false)
     runnable = Minitest::Test.new(name)
     runnable.failures << generate_assertion(failure) if failure
-    runnable.failures << MiniTest::Skip.new if skipped
+    runnable.failures << Minitest::Skip.new if skipped
     runnable.failures << generate_unexpected_error if unexpected_error
-    runnable.failures << MiniTest::Requeue.new(generate_assertion("Failed")) if requeued
+    runnable.failures << Minitest::Requeue.new(generate_assertion("Failed")) if requeued
     runnable.assertions += 1
     runnable.time = 0.12
     runnable


### PR DESCRIPTION
Reverts Shopify/ci-queue#142

We reverted #141 because we don't have a runtime dependency on minitest, only a development dependency which won't get enforced when people install it in their project.