### PR TITLE
 JUnitXML reporter: add run-command property to test case tags

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'shellwords'
 require 'minitest'
 require 'minitest/reporters'
 
@@ -102,6 +103,37 @@ module Minitest
   end
 
   module Queue
+    attr_writer :run_command_formatter
+
+    def run_command_formatter
+      @run_command_formatter ||= if defined?(Railties)
+        RAILS_RUN_COMMAND_FORMATTER
+      else
+        DEFAULT_RUN_COMMAND_FORMATTER
+      end
+    end
+
+    DEFAULT_RUN_COMMAND_FORMATTER = lambda do |runnable|
+      filename = runnable.source_location[0]
+      identifier = "#{runnable.klass}##{runnable.name}"
+      ['bundle', 'exec', 'ruby', '-Ilib:test', filename, '-n', identifier]
+    end
+
+    RAILS_RUN_COMMAND_FORMATTER = lambda do |runnable|
+      filename = runnable.source_location[0]
+      lineno = runnable.source_location[1]
+      ['bin/rails', 'test', "#{filename}:#{lineno}"]
+    end
+
+    def run_command_for_runnable(runnable)
+      command = run_command_formatter.call(runnable)
+      if command.is_a?(Array)
+        Shellwords.join(command)
+      else
+        command
+      end
+    end
+
     class SingleExample
 
       def initialize(runnable, method_name)

--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -79,7 +79,8 @@ module Minitest
             'classname' => suite,
             'assertions' => test.assertions,
             'time' => test.time,
-            'flaky_test' => test.flaked?
+            'flaky_test' => test.flaked?,
+            'run-command' => Minitest.run_command_for_runnable(test),
           }
           attributes['lineno'] = lineno if lineno != -1
 

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -422,13 +422,13 @@ module Integration
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="ATest" filepath="test/dummy_test.rb" skipped="5" failures="1" errors="0" tests="6" assertions="5" time="X.XX">
-            <testcase name="test_foo" classname="ATest" assertions="0" time="X.XX" flaky_test="false" lineno="5">
+            <testcase name="test_foo" classname="ATest" assertions="0" time="X.XX" flaky_test="false" run-command=\"bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_foo\" lineno="5">
               <skipped type="Minitest::Skip"/>
             </testcase>
-            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" lineno="5">
+            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" run-command=\"bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_bar\" lineno="5">
               <skipped type="Minitest::Assertion"/>
             </testcase>
-            <testcase name="test_flaky" classname="ATest" assertions="1" time="X.XX" flaky_test="true" lineno="5">
+            <testcase name="test_flaky" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command=\"bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_flaky\" lineno="5">
               <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Skipped:
@@ -437,8 +437,8 @@ module Integration
         ]]>
               </failure>
             </testcase>
-            <testcase name="test_flaky_passes" classname="ATest" assertions="1" time="X.XX" flaky_test="true" lineno="5"/>
-            <testcase name="test_flaky_fails_retry" classname="ATest" assertions="1" time="X.XX" flaky_test="true" lineno="5">
+            <testcase name="test_flaky_passes" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_flaky_passes" lineno="5"/>
+            <testcase name="test_flaky_fails_retry" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_flaky_fails_retry" lineno="5">
               <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Skipped:
@@ -447,7 +447,7 @@ module Integration
         ]]>
               </failure>
             </testcase>
-            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" lineno="5">
+            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_bar" lineno="5">
               <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Failure:
@@ -458,11 +458,11 @@ module Integration
             </testcase>
           </testsuite>
           <testsuite name="BTest" filepath="test/dummy_test.rb" skipped="1" failures="0" errors="1" tests="3" assertions="1" time="X.XX">
-            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" lineno="36">
+            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n BTest\\#test_bar" lineno="36">
               <skipped type="TypeError"/>
             </testcase>
-            <testcase name="test_foo" classname="BTest" assertions="1" time="X.XX" flaky_test="false" lineno="36"/>
-            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" lineno="36">
+            <testcase name="test_foo" classname="BTest" assertions="1" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n BTest\\#test_foo" lineno="36"/>
+            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n BTest\\#test_bar" lineno="36">
               <error type="TypeError" message="TypeError: String can&apos;t be coerced into Integer">
                 <![CDATA[
         Failure:

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -422,54 +422,54 @@ module Integration
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="ATest" filepath="test/dummy_test.rb" skipped="5" failures="1" errors="0" tests="6" assertions="5" time="X.XX">
-            <testcase name="test_foo" classname="ATest" assertions="0" time="X.XX" flaky_test="false" run-command=\"bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_foo\" lineno="5">
+            <testcase name="test_foo" classname="ATest" assertions="0" time="X.XX" flaky_test="false" run-command=\"bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_foo\" lineno="5">
               <skipped type="Minitest::Skip"/>
             </testcase>
-            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" run-command=\"bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_bar\" lineno="5">
+            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" run-command=\"bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_bar\" lineno="5">
               <skipped type="Minitest::Assertion"/>
             </testcase>
-            <testcase name="test_flaky" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command=\"bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_flaky\" lineno="5">
+            <testcase name="test_flaky" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command=\"bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_flaky\" lineno="5">
               <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Skipped:
-        test_flaky(ATest) [./test/fixtures/test/dummy_test.rb:18]:
+        test_flaky(ATest) [test/dummy_test.rb]:
         Expected false to be truthy.
         ]]>
               </failure>
             </testcase>
-            <testcase name="test_flaky_passes" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_flaky_passes" lineno="5"/>
-            <testcase name="test_flaky_fails_retry" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_flaky_fails_retry" lineno="5">
+            <testcase name="test_flaky_passes" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_flaky_passes" lineno="5"/>
+            <testcase name="test_flaky_fails_retry" classname="ATest" assertions="1" time="X.XX" flaky_test="true" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_flaky_fails_retry" lineno="5">
               <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Skipped:
-        test_flaky_fails_retry(ATest) [./test/fixtures/test/dummy_test.rb:23]:
+        test_flaky_fails_retry(ATest) [test/dummy_test.rb]:
         Expected false to be truthy.
         ]]>
               </failure>
             </testcase>
-            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n ATest\\#test_bar" lineno="5">
+            <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_bar" lineno="5">
               <failure type="Minitest::Assertion" message="Expected false to be truthy.">
                 <![CDATA[
         Failure:
-        test_bar(ATest) [./test/fixtures/test/dummy_test.rb:10]:
+        test_bar(ATest) [test/dummy_test.rb]:
         Expected false to be truthy.
         ]]>
               </failure>
             </testcase>
           </testsuite>
           <testsuite name="BTest" filepath="test/dummy_test.rb" skipped="1" failures="0" errors="1" tests="3" assertions="1" time="X.XX">
-            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n BTest\\#test_bar" lineno="36">
+            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n BTest\\#test_bar" lineno="36">
               <skipped type="TypeError"/>
             </testcase>
-            <testcase name="test_foo" classname="BTest" assertions="1" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n BTest\\#test_foo" lineno="36"/>
-            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" run-command="bundle exec ruby ./test/fixtures/test/dummy_test.rb -n BTest\\#test_bar" lineno="36">
+            <testcase name="test_foo" classname="BTest" assertions="1" time="X.XX" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n BTest\\#test_foo" lineno="36"/>
+            <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n BTest\\#test_bar" lineno="36">
               <error type="TypeError" message="TypeError: String can&apos;t be coerced into Integer">
                 <![CDATA[
         Failure:
-        test_bar(BTest) [./test/fixtures/test/dummy_test.rb:37]:
+        test_bar(BTest) [test/dummy_test.rb]:
         TypeError: String can't be coerced into Integer
-            ./test/fixtures/test/dummy_test.rb:37:in `+'
-            ./test/fixtures/test/dummy_test.rb:37:in `test_bar'
+            test/dummy_test.rb:37:in `+'
+            test/dummy_test.rb:37:in `test_bar'
         ]]>
               </error>
             </testcase>

--- a/ruby/test/minitest/queue/run_command_formatter_test.rb
+++ b/ruby/test/minitest/queue/run_command_formatter_test.rb
@@ -5,6 +5,10 @@ module Minitest::Queue
   class RunCommandFormatterTest < Minitest::Test
     include ReporterTestHelper
 
+    def teardown
+      Minitest.run_command_formatter = Minitest::Queue::DEFAULT_RUN_COMMAND_FORMATTER
+    end
+
     def test_default_formatter
       result = result('a', failure: "Something went wrong")
 

--- a/ruby/test/minitest/queue/run_command_formatter_test.rb
+++ b/ruby/test/minitest/queue/run_command_formatter_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Minitest::Queue
+  class RunCommandFormatterTest < Minitest::Test
+    include ReporterTestHelper
+
+    def test_default_formatter
+      result = result('a', failure: "Something went wrong")
+
+      formatter = Minitest::Queue::DEFAULT_RUN_COMMAND_FORMATTER
+      command_arguments = formatter.call(result)
+      assert_equal %w[bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test#a], command_arguments
+    end
+
+    def test_rails_formatter
+      result = result('a', failure: "Something went wrong")
+
+      formatter = Minitest::Queue::RAILS_RUN_COMMAND_FORMATTER
+      command_arguments = formatter.call(result)
+      assert_equal %w[bin/rails test test/my_test.rb:12], command_arguments
+    end
+
+    def test_format_run_command_with_custom_formatter_returning_string
+      Minitest.run_command_formatter = lambda do |result|
+        "testrunner #{result.klass}##{result.name}"
+      end
+
+      command = Minitest.run_command_for_runnable(result('a'))
+      assert_equal 'testrunner Minitest::Test#a', command
+    end
+
+    def test_format_run_command_with_custom_formatter_returning_array
+      Minitest.run_command_formatter = lambda do |result|
+        ["test runner", "#{result.klass}##{result.name}"]
+      end
+
+      command = Minitest.run_command_for_runnable(result('a'))
+      assert_equal %{test\\ runner Minitest::Test\\#a}, command
+    end
+  end
+end

--- a/ruby/test/minitest/queue/run_command_formatter_test.rb
+++ b/ruby/test/minitest/queue/run_command_formatter_test.rb
@@ -42,5 +42,25 @@ module Minitest::Queue
       command = Minitest.run_command_for_runnable(result('a'))
       assert_equal %{test\\ runner Minitest::Test\\#a}, command
     end
+
+    def test_relative_path
+      path = Minitest::Queue.relative_path('/home/willem/src/project/test/my_test.rb', root: '/home/willem/src/project')
+      assert_equal "test/my_test.rb", path
+    end
+
+    def test_relative_path_with_wrong_base_dir
+      path = Minitest::Queue.relative_path('/home/willem/src/project/test/my_test.rb', root: '/home/willem/src/other_project')
+      assert_equal "../project/test/my_test.rb", path
+    end
+
+    def test_relative_path_already_relative
+      path = Minitest::Queue.relative_path('./test/my_test.rb', root: '/home/willem/src/project')
+      assert_equal "./test/my_test.rb", path
+    end
+
+    def test_relative_path_with_empty_path
+      path = Minitest::Queue.relative_path('', root: '/home/willem/src/project')
+      assert_equal "", path
+    end
   end
 end

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -18,8 +18,8 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="0" errors="0" tests="2" assertions="2" time="0.24">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12"/>
-            <testcase name="test_bar" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12"/>
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12"/>
+            <testcase name="test_bar" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_bar" lineno="12"/>
           </testsuite>
         </testsuites>
       XML
@@ -32,7 +32,7 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="1" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <failure type="Minitest::Assertion" message="Assertion failed">
                 <![CDATA[
         Failure:
@@ -53,7 +53,7 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="1" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <failure type="Minitest::Assertion" message="Assertion failed">
                 <![CDATA[
         Failure:
@@ -74,7 +74,7 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <skipped type="Minitest::Skip"/>
             </testcase>
           </testsuite>
@@ -89,7 +89,7 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="0" errors="1" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <error type="StandardError" message="StandardError: StandardError">
                 <![CDATA[
         Failure:
@@ -113,7 +113,7 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <skipped type="Minitest::Assertion"/>
             </testcase>
           </testsuite>

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -18,8 +18,8 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="0" errors="0" tests="2" assertions="2" time="0.24">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12"/>
-            <testcase name="test_bar" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_bar" lineno="12"/>
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12"/>
+            <testcase name="test_bar" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_bar" lineno="12"/>
           </testsuite>
         </testsuites>
       XML
@@ -32,11 +32,11 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="1" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <failure type="Minitest::Assertion" message="Assertion failed">
                 <![CDATA[
         Failure:
-        test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
+        test_foo(Minitest::Test) [test/my_test.rb]:
         Assertion failed
         ]]>
               </failure>
@@ -53,11 +53,11 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="1" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <failure type="Minitest::Assertion" message="Assertion failed">
                 <![CDATA[
         Failure:
-        test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
+        test_foo(Minitest::Test) [test/my_test.rb]:
         \e[31mAssertion failed\e[0m
         ]]>
               </failure>
@@ -74,7 +74,7 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <skipped type="Minitest::Skip"/>
             </testcase>
           </testsuite>
@@ -89,15 +89,15 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="0" errors="1" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <error type="StandardError" message="StandardError: StandardError">
                 <![CDATA[
         Failure:
-        test_foo(Minitest::Test) [#{Dir.pwd}/test/support/reporter_test_helper.rb:15]:
+        test_foo(Minitest::Test) [test/my_test.rb]:
         StandardError: StandardError
-            #{Dir.pwd}/test/support/reporter_test_helper.rb:15:in `runnable'
-            #{Dir.pwd}/test/support/reporter_test_helper.rb:6:in `result'
-            #{Dir.pwd}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'
+            test/support/reporter_test_helper.rb:15:in `runnable'
+            test/support/reporter_test_helper.rb:6:in `result'
+            test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'
         ]]>
               </error>
             </testcase>
@@ -113,7 +113,7 @@ module Minitest::Reporters
         <?xml version="1.1" encoding="UTF-8"?>
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
-            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
+            <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
               <skipped type="Minitest::Assertion"/>
             </testcase>
           </testsuite>

--- a/ruby/test/support/reporter_test_helper.rb
+++ b/ruby/test/support/reporter_test_helper.rb
@@ -4,7 +4,7 @@ module ReporterTestHelper
 
   def result(name, **kwargs)
     result = Minitest::Result.from(runnable(name, **kwargs))
-    result.source_location = ["test/my_test.rb", 12]
+    result.source_location = ["#{Minitest::Queue.project_root}/test/my_test.rb", 12]
     result
   end
 
@@ -22,9 +22,9 @@ module ReporterTestHelper
   def generate_unexpected_error
     error = StandardError.new
     error.set_backtrace([
-      "#{Dir.pwd}/test/support/reporter_test_helper.rb:15:in `runnable'",
-      "#{Dir.pwd}/test/support/reporter_test_helper.rb:6:in `result'",
-      "#{Dir.pwd}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
+      "#{Minitest::Queue.project_root}/test/support/reporter_test_helper.rb:15:in `runnable'",
+      "#{Minitest::Queue.project_root}/test/support/reporter_test_helper.rb:6:in `result'",
+      "#{Minitest::Queue.project_root}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
     ])
     Minitest::UnexpectedError.new(error)
   end
@@ -34,9 +34,9 @@ module ReporterTestHelper
 
     error = Minitest::Assertion.new(message)
     error.set_backtrace([
-      "#{Dir.pwd}/test/support/reporter_test_helper.rb:15:in `runnable'",
-      "#{Dir.pwd}/test/support/reporter_test_helper.rb:6:in `result'",
-      "#{Dir.pwd}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
+      "#{Minitest::Queue.project_root}/test/support/reporter_test_helper.rb:15:in `runnable'",
+      "#{Minitest::Queue.project_root}/test/support/reporter_test_helper.rb:6:in `result'",
+      "#{Minitest::Queue.project_root}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
     ])
     error
   end


### PR DESCRIPTION
When generating JUnitXML, include a `run-command` attribute in every `<testcase>` tag. Readers of the file can use this to tell users how they can re-run tests to diagnose issues.

Because test runners differ between environments, we allow people to register a `run_command_formatter` that returns the run command. We ship it with a basic one that runs tests using `bundle exec ruby -Ilib:test<testfile> -n `<testname>`, and a different formatter for when the Rails test runner is found.