### PR TITLE
Properly remove project root from paths

### DIFF
--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -96,13 +96,16 @@ module Minitest
         message.lines.first.chomp.gsub(/\e\[[^m]+m/, '')
       end
 
+      def project_root_path_matcher
+        @project_root_path_matcher ||= %r{(?<=\s)#{Regexp.escape(Minitest::Queue.project_root)}/}
+      end
+
       def message_for(test)
         suite = test.klass
         name = test.name
         error = test.failure
 
-        message_with_relative_paths = error.message.gsub("#{Minitest::Queue.project_root}/", '')
-
+        message_with_relative_paths = error.message.gsub(project_root_path_matcher, '')
         if test.passed?
           nil
         elsif test.skipped?

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -97,13 +97,39 @@ module Minitest::Reporters
         StandardError: StandardError
             test/support/reporter_test_helper.rb:15:in `runnable'
             test/support/reporter_test_helper.rb:6:in `result'
-            test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'
+            app/components/app/test/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'
         ]]>
               </error>
             </testcase>
           </testsuite>
         </testsuites>
       XML
+    end
+
+    def test_generate_junitxml_with_proper_relative_paths
+      Minitest::Queue.stub(:project_root, '/app') do
+        @reporter.record(result("test_foo", unexpected_error: true))
+
+        assert_equal <<~XML, generate_xml(@reporter)
+          <?xml version="1.1" encoding="UTF-8"?>
+          <testsuites>
+            <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="0" errors="1" tests="1" assertions="1" time="0.12">
+              <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
+                <error type="StandardError" message="StandardError: StandardError">
+                  <![CDATA[
+          Failure:
+          test_foo(Minitest::Test) [test/my_test.rb]:
+          StandardError: StandardError
+              test/support/reporter_test_helper.rb:15:in `runnable'
+              test/support/reporter_test_helper.rb:6:in `result'
+              app/components/app/test/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'
+          ]]>
+                </error>
+              </testcase>
+            </testsuite>
+          </testsuites>
+        XML
+      end
     end
 
     def test_generate_junitxml_for_requeued_test

--- a/ruby/test/support/reporter_test_helper.rb
+++ b/ruby/test/support/reporter_test_helper.rb
@@ -24,7 +24,7 @@ module ReporterTestHelper
     error.set_backtrace([
       "#{Minitest::Queue.project_root}/test/support/reporter_test_helper.rb:15:in `runnable'",
       "#{Minitest::Queue.project_root}/test/support/reporter_test_helper.rb:6:in `result'",
-      "#{Minitest::Queue.project_root}/test/minitest/reporters/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
+      "#{Minitest::Queue.project_root}/app/components/app/test/junit_reporter_test.rb:65:in `test_generate_junitxml_for_errored_test'",
     ])
     Minitest::UnexpectedError.new(error)
   end


### PR DESCRIPTION
Fixes #146.

We were too eagerly removing the project root from paths we encounter in assertion messages. Specifically, because our application root is `/app/` on CI, we swould be stripping out path from with paths as well (e.g. `/app/components/app/test/blah.rb` would have the second `/app` stripped).

This fix uses a regular expression to make sure we only remove the project root it from the beginning of stacktrace lines, where they are always at the same place on the line.