### PR TITLE
add test suite to failure  file

### DIFF
--- a/ruby/lib/minitest/queue/error_report.rb
+++ b/ruby/lib/minitest/queue/error_report.rb
@@ -58,6 +58,10 @@ module Minitest
         @data[:test_and_module_name]
       end
 
+      def test_suite
+        @data[:test_suite]
+      end
+
       def test_file
         @data[:test_file]
       end

--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -27,6 +27,7 @@ module Minitest
           test_line: test_line,
           test_and_module_name: "#{test.klass}##{test.name}",
           test_name: test.name,
+          test_suite: test.klass,
           error_class: test.failure.exception.class.name,
           output: to_s,
         }

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -523,10 +523,12 @@ module Integration
           test_and_module_name: "ATest#test_bar",
           error_class: "Minitest::Assertion",
           test_name: "test_bar",
+          test_suite: "ATest",
         }
 
         assert_includes failure[:test_file], expected[:test_file]
         assert_equal failure[:test_line], expected[:test_line]
+        assert_equal failure[:test_suite], expected[:test_suite]
         assert_equal failure[:test_and_module_name], expected[:test_and_module_name]
         assert_equal failure[:test_name], expected[:test_name]
         assert_equal failure[:error_class], expected[:error_class]


### PR DESCRIPTION
The failure file didn't have data on a test suite, so I'm adding it here.

Fixes once deployed in core: https://github.com/Shopify/test-oversight-service/issues/51