### PR TITLE
add deprecation message to rspec command

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -53,7 +53,7 @@ minitest-queue --queue path/to/test_order.log --failing-test 'SomeTest#test_some
 
 ### RSpec [DEPRECATED]
 
-> The rspec-queue runner is deprecated. The minitest-queue runner continues to be supported and is actively being improved. We recommend that new projects to set up their test suite using Minitest.
+The rspec-queue runner is deprecated. The minitest-queue runner continues to be supported and is actively being improved. At Shopify, we strongly recommend that new projects set up their test suite using Minitest rather than RSpec.
 
 Assuming you use one of the supported CI providers, the command can be as simple as:
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -69,4 +69,4 @@ rspec-queue --queue redis://example.com --timeout 600 --report
 
 #### Limitations
 
-Because of how `ci-queue` execute the examples, `before(:all)` and `after(:all)` hooks are not supported. `rspec-queue` will explicitly reject them.
+Because of how `ci-queue` executes the examples, `before(:all)` and `after(:all)` hooks are not supported. `rspec-queue` will explicitly reject them.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -53,7 +53,7 @@ minitest-queue --queue path/to/test_order.log --failing-test 'SomeTest#test_some
 
 ### RSpec [DEPRECATED]
 
-> ⛔️ The rspec-queue runner is DEPRECATED, so we can focus on the minitest-queue runner exclusively and improve it more.
+> The rspec-queue runner is deprecated. The minitest-queue runner continues to be supported and is actively being improved. We recommend that new projects to set up their test suite using Minitest.
 
 Assuming you use one of the supported CI providers, the command can be as simple as:
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -51,7 +51,9 @@ The runner also comes with a tool to investigate leaky tests:
 minitest-queue --queue path/to/test_order.log --failing-test 'SomeTest#test_something' bisect -Itest test/**/*_test.rb
 ```
 
-### RSpec
+### RSpec [DEPRECATED]
+
+> ⛔️ The rspec-queue runner is DEPRECATED, so we can focus on the minitest-queue runner exclusively and improve it more.
 
 Assuming you use one of the supported CI providers, the command can be as simple as:
 


### PR DESCRIPTION
This PR adds a message when the rspec test runner is invoked that it is deprecated.

reference https://github.com/Shopify/test-infra/issues/350