### PR TITLE
Remove dependency on minitest-reporters

### DIFF
--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'redis', '~> 3.3'
   spec.add_development_dependency 'simplecov', '~> 0.12'
-  spec.add_development_dependency 'minitest-reporters', '~> 1.1'
 
   spec.add_development_dependency 'snappy'
   spec.add_development_dependency 'msgpack'

--- a/ruby/lib/minitest/ci_queue_plugin.rb
+++ b/ruby/lib/minitest/ci_queue_plugin.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Minitest
+  class << self
+    def plugin_ci_queue_init(_options)
+      if Minitest.queue_reporters
+        reporter.reporters.delete_if { |reporter| reporter.is_a?(SummaryReporter) }
+        reporter.reporters.delete_if { |reporter| reporter.is_a?(ProgressReporter) }
+        Minitest.queue_reporters.each do |queue_reporter|
+          reporter << queue_reporter
+        end
+      end
+
+      if Minitest.backtrace_filter.respond_to?(:add_silencer)
+        # Backtrace filter installed by Rails
+        Minitest.backtrace_filter.add_filter { |line| line =~ %r{exe/minitest-queue|lib/ci/queue} }
+      elsif Minitest.backtrace_filter.respond_to?(:add_filter)
+        # Backtrace filter installed by minitest-reporters
+        Minitest.backtrace_filter.add_filter(%r{exe/minitest-queue|lib/ci/queue})
+      else
+        # Replace the backtrace filter
+        # TODO: do we want to replace the standard filter that minitest ships with?
+      end
+    end
+  end
+end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -2,6 +2,7 @@
 require 'shellwords'
 require 'minitest'
 require 'minitest/reporters'
+require 'minitest/reporters/base_reporter_shim'
 
 require 'minitest/queue/failure_formatter'
 require 'minitest/queue/error_report'

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'shellwords'
 require 'minitest'
-require 'minitest/reporters'
 require 'minitest/reporters/base_reporter_shim'
 
 require 'minitest/queue/failure_formatter'
@@ -169,18 +168,8 @@ module Minitest
       end
     end
 
-    attr_reader :queue
-
-    def queue=(queue)
-      @queue = queue
-    end
-
-    def queue_reporters=(reporters)
-      @queue_reporters ||= []
-      Reporters.use!(((Reporters.reporters || []) - @queue_reporters) + reporters)
-      Minitest.backtrace_filter.add_filter(%r{exe/minitest-queue|lib/ci/queue/})
-      @queue_reporters = reporters
-    end
+    attr_accessor :queue_reporters
+    attr_accessor :queue
 
     def loaded_tests
       Minitest::Test.runnables.flat_map do |runnable|

--- a/ruby/lib/minitest/queue/build_status_recorder.rb
+++ b/ruby/lib/minitest/queue/build_status_recorder.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
-require 'minitest/reporters'
 
 module Minitest
   module Queue
-    class BuildStatusRecorder < Minitest::Reporters::BaseReporter
+    class BuildStatusRecorder < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
+
       COUNTERS = %w(
         assertions
         errors
@@ -18,7 +19,7 @@ module Minitest
       end
       self.failure_formatter = FailureFormatter
 
-      attr_accessor :requeues
+      attr_accessor :failures, :errors, :skips, :requeues, :assertions, :total_time
 
       def initialize(build:, **options)
         super(options)
@@ -28,38 +29,40 @@ module Minitest
         self.errors = 0
         self.skips = 0
         self.requeues = 0
+        self.total_time = 0.0
+        self.assertions = 0
       end
 
       def report
         # noop
       end
 
-      def record(test)
-        super
+      def record(result)
+        self.total_time += result.time
+        self.assertions += result.assertions
 
-        self.total_time = Minitest.clock_time - start_time
-        if test.requeued?
+        if result.requeued?
           self.requeues += 1
-        elsif test.skipped?
+        elsif result.skipped?
           self.skips += 1
-        elsif test.error?
+        elsif result.error?
           self.errors += 1
-        elsif test.failure
+        elsif result.failure
           self.failures += 1
         end
 
         stats = COUNTERS.zip(COUNTERS.map { |c| send(c) }).to_h
-        if (test.failure || test.error?) && !test.skipped?
-          build.record_error("#{test.klass}##{test.name}", dump(test), stats: stats)
+        if (result.failure || result.error?) && !result.skipped?
+          build.record_error("#{result.klass}##{result.name}", dump(result), stats: stats)
         else
-          build.record_success("#{test.klass}##{test.name}", stats: stats)
+          build.record_success("#{result.klass}##{result.name}", stats: stats)
         end
       end
 
       private
 
-      def dump(test)
-        ErrorReport.new(self.class.failure_formatter.new(test).to_h).dump
+      def dump(result)
+        ErrorReport.new(self.class.failure_formatter.new(result).to_h).dump
       end
 
       attr_reader :build

--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+
 module Minitest
   module Queue
-    class BuildStatusReporter < Minitest::Reporters::BaseReporter
+    class BuildStatusReporter < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
       include ::CI::Queue::OutputHelpers
 
       def initialize(build:, **options)

--- a/ruby/lib/minitest/queue/error_report.rb
+++ b/ruby/lib/minitest/queue/error_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Minitest
   module Queue
     class ErrorReport

--- a/ruby/lib/minitest/queue/grind_recorder.rb
+++ b/ruby/lib/minitest/queue/grind_recorder.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+
 module Minitest
   module Queue
-    class GrindRecorder < Minitest::Reporters::BaseReporter
+    class GrindRecorder < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
 
       attr_accessor :test_count
 

--- a/ruby/lib/minitest/queue/grind_reporter.rb
+++ b/ruby/lib/minitest/queue/grind_reporter.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'minitest/reporters'
 
 module Minitest
   module Queue
-    class GrindReporter < Minitest::Reporters::BaseReporter
+    class GrindReporter < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
       include ::CI::Queue::OutputHelpers
 
       def initialize(build:, **options)

--- a/ruby/lib/minitest/queue/local_requeue_reporter.rb
+++ b/ruby/lib/minitest/queue/local_requeue_reporter.rb
@@ -1,21 +1,22 @@
 # frozen_string_literal: true
 require 'ci/queue/output_helpers'
-require 'minitest/reporters'
 
 module Minitest
   module Queue
-    class LocalRequeueReporter < Minitest::Reporters::BaseReporter
+    class LocalRequeueReporter < Minitest::StatisticsReporter
+      include Minitest::Reporters::BaseReporterShim
       include ::CI::Queue::OutputHelpers
+
       attr_accessor :requeues
 
       def initialize(*)
-        self.requeues = 0
         super
       end
 
       def report
-        self.requeues = results.count(&:requeued?)
         super
+        self.requeues = results.count { |r| r.failure.is_a?(Minitest::Requeue) }
+
         print_report
       end
 

--- a/ruby/lib/minitest/queue/order_reporter.rb
+++ b/ruby/lib/minitest/queue/order_reporter.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-require 'minitest/reporters'
 
-class Minitest::Queue::OrderReporter < Minitest::Reporters::BaseReporter
+class Minitest::Queue::OrderReporter < Minitest::Reporter
+  include Minitest::Reporters::BaseReporterShim
+
   def initialize(options = {})
     @path = options.delete(:path)
     super
@@ -9,12 +10,10 @@ class Minitest::Queue::OrderReporter < Minitest::Reporters::BaseReporter
 
   def start
     @file = File.open(@path, 'w+')
-    super
   end
 
-  def before_test(test)
-    super
-    @file.puts("#{test.class.name}##{test.name}")
+  def prerecord(test_class, name)
+    @file.puts("#{test_class.name}##{name}")
     @file.flush
   end
 

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -254,7 +254,7 @@ module Minitest
       def run_tests_in_fork(queue)
         child_pid = fork do
           Minitest.queue = queue
-          Minitest::Reporters.use!([Minitest::Reporters::BisectReporter.new])
+          Minitest.queue_reporters = [Minitest::Reporters::BisectReporter.new]
           exit # let minitest excute its at_exit
         end
 

--- a/ruby/lib/minitest/queue/test_data.rb
+++ b/ruby/lib/minitest/queue/test_data.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'minitest/reporters'
+
 require 'fileutils'
 
 module Minitest

--- a/ruby/lib/minitest/queue/test_data_reporter.rb
+++ b/ruby/lib/minitest/queue/test_data_reporter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'minitest/reporters'
+
 require 'fileutils'
 require 'json'
 
@@ -7,18 +7,23 @@ require 'minitest/queue/test_data'
 
 module Minitest
   module Queue
-    class TestDataReporter < Minitest::Reporters::BaseReporter
+    class TestDataReporter < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
+
       def initialize(report_path: 'log/test_data.json', base_path: nil, namespace: '')
         super({})
         @report_path = File.absolute_path(report_path)
         @base_path = base_path || Dir.pwd
         @namespace = namespace || ''
+        @results = []
+      end
+
+      def record(result)
+        @results << result
       end
 
       def report
-        super
-
-        result = tests.map.with_index do |test, index|
+        result = @results.map.with_index do |test, index|
           Queue::TestData.new(test: test, index: index,
                               base_path: @base_path, namespace: @namespace).to_h
         end.to_json

--- a/ruby/lib/minitest/queue/test_time_recorder.rb
+++ b/ruby/lib/minitest/queue/test_time_recorder.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
+
 module Minitest
   module Queue
-    class TestTimeRecorder < Minitest::Reporters::BaseReporter
+    class TestTimeRecorder < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
+
       def initialize(build:, **options)
         super(options)
         @build = build

--- a/ruby/lib/minitest/queue/test_time_reporter.rb
+++ b/ruby/lib/minitest/queue/test_time_reporter.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'minitest/reporters'
 
 module Minitest
   module Queue
-    class TestTimeReporter < Minitest::Reporters::BaseReporter
+    class TestTimeReporter < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
       include ::CI::Queue::OutputHelpers
 
       def initialize(build:, limit: nil, percentile: nil, **options)

--- a/ruby/lib/minitest/reporters/base_reporter_shim.rb
+++ b/ruby/lib/minitest/reporters/base_reporter_shim.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Minitest
+  module Reporters
+    # This module provides compatibility with Minitest::Reporters::BaseReporter
+    module BaseReporterShim
+      def before_test(*); end
+      def after_test(*); end
+    end
+  end
+end

--- a/ruby/lib/minitest/reporters/bisect_reporter.rb
+++ b/ruby/lib/minitest/reporters/bisect_reporter.rb
@@ -1,16 +1,35 @@
 # frozen_string_literal: true
-require 'minitest/reporters'
 
 module Minitest
   module Reporters
-    class BisectReporter < BaseReporter
-      include RelativePosition
+    class BisectReporter < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
 
-      def record(test)
-        super
-        test_name = "#{test.klass}##{test.name}"
-        print pad_test(test_name)
-        puts pad_mark(result(test).to_s.upcase)
+      def start
+        @failure_detected = false
+      end
+
+      def record(result)
+        @failure_detected ||= !(result.passed? || result.skipped?)
+        puts format("  %-63s %s", "#{result.class_name}##{result.name}", result_label(result))
+      end
+
+      def passed?
+        !@failure_detected
+      end
+
+      private
+
+      def result_label(result)
+        if result.passed?
+          'PASS'
+        elsif result.skipped?
+          'SKIP'
+        elsif result.error?
+          'ERROR'
+        else
+          'FAIL'
+        end
       end
     end
   end

--- a/ruby/lib/minitest/reporters/statsd_reporter.rb
+++ b/ruby/lib/minitest/reporters/statsd_reporter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'minitest/queue'
 require 'minitest/queue/statsd'
-require 'minitest/reporters'
 
 module Minitest
   module Reporters

--- a/ruby/lib/minitest/reporters/statsd_reporter.rb
+++ b/ruby/lib/minitest/reporters/statsd_reporter.rb
@@ -5,7 +5,8 @@ require 'minitest/reporters'
 
 module Minitest
   module Reporters
-    class StatsdReporter < Minitest::Reporters::BaseReporter
+    class StatsdReporter < Minitest::Reporter
+      include Minitest::Reporters::BaseReporterShim
       FAILING_INFRASTRUCTURE_THRESHOLD = 10
 
       attr_reader :statsd

--- a/ruby/test/integration/minitest_bisect_test.rb
+++ b/ruby/test/integration/minitest_bisect_test.rb
@@ -95,7 +95,7 @@ module Integration
       assert_equal expected_output, normalize(out)
     end
 
-    def test_unconclusive
+    def test_inconclusive
       out, err = capture_subprocess_io do
         run_bisect('log/unconclusive_test_order.log', 'LeakyTest#test_sensible_to_leak')
       end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -590,7 +590,7 @@ module Integration
 
         ERROR BTest#test_bar
       END
-      assert output.include?(expected_output)
+      assert_includes output, expected_output
     end
 
     def test_utf8_tests_and_marshal

--- a/ruby/test/minitest/queue/order_reporter_test.rb
+++ b/ruby/test/minitest/queue/order_reporter_test.rb
@@ -10,9 +10,9 @@ module Minitest::Queue
       @reporter.start
     end
 
-    def test_before_test
-      @reporter.before_test(runnable('a'))
-      @reporter.before_test(runnable('b'))
+    def test_prerecord
+      @reporter.prerecord(Minitest::Test, 'a')
+      @reporter.prerecord(Minitest::Test, 'b')
       @reporter.report
       assert_equal ['Minitest::Test#a', 'Minitest::Test#b'], File.readlines(log_path).map(&:chomp)
     end

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "test_helper"
-require "minitest/reporters/junit_reporter"
 
 module Minitest::Reporters
   class JUnitReporterTest < Minitest::Test

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -10,8 +10,6 @@ require 'ci/queue/redis'
 require 'minitest/queue'
 require 'minitest/autorun'
 
-Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
-
 require 'tmpdir'
 require 'thread'
 require 'stringio'


### PR DESCRIPTION
This is more of a proof of concept than anything else at this point. 

Because `minitest-reporters` does not play well with the minitest plugin ecosystem, it can cause issues. E.g. if you are using `Minitest::Reporters.use!` in a `test_helper.rb` it will silently get rid of any reporter that plugins may want to register in their plugin hook. Specifically, people may overwrite the reporters that are necessary for ci-queue to work properly. This can cause builds that are supposed to be red to show up green, which has happened in two of our repositories.

I think we have two ways to deal with this: either embrace minitest-reporters with everything we do, or stop using it and use minitest plugins instead. There's pros and cons for both.

In this PR I am exploring the second option: not using minitest-reporters, but use a minitest plugin instead. The implementation is not complete (test failures are related to not using minitest-reporters's backtrace silencer). Also, it doesn't really defend against people using `Minitest::Reporters.use!` and overwrite these reporters, so we would have to do something about that.

At this point, I am open to feedback about this approach, and whether this makes sense to go down this path. Or alternatively, why we should go down the `Minitest::Reporters` path.