### PR TITLE
Support redis >= 4.2

### DIFF
--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')
   spec.add_development_dependency 'rspec', '~> 3.7.0'
-  spec.add_development_dependency 'redis', '~> 3.3'
+  spec.add_development_dependency 'redis'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'minitest-reporters', '~> 1.1'
 

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -56,10 +56,18 @@ module CI
         rescue *CONNECTION_ERRORS
         end
 
-        def retrying?
-          redis.exists(key('worker', worker_id, 'queue'))
-        rescue *CONNECTION_ERRORS
-          false
+        if ::Redis.method_defined?(:exists?)
+          def retrying?
+            redis.exists?(key('worker', worker_id, 'queue'))
+          rescue *CONNECTION_ERRORS
+            false
+          end
+        else
+          def retrying?
+            redis.exists(key('worker', worker_id, 'queue'))
+          rescue *CONNECTION_ERRORS
+            false
+          end
         end
 
         def retry_queue


### PR DESCRIPTION
Redis 4.2 is somewhat deprecating `exists` for `exists?`. 

So we should use that one in priority if it's available.