### PR TITLE
Add minitest reporters as a dependency of this project

### DIFF
--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -29,13 +29,14 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
+  spec.add_dependency 'minitest-reporters', '~> 1.1'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'redis'
   spec.add_development_dependency 'simplecov', '~> 0.12'
-  spec.add_development_dependency 'minitest-reporters', '~> 1.1'
 
   spec.add_development_dependency 'snappy'
   spec.add_development_dependency 'msgpack'


### PR DESCRIPTION
This is required since  github.com/Shopify/ci-queue/commit/ef11b11d79048a3e951480669ab1d5f60b690b49