### PR TITLE
Add error_message to ErrorReporter

### DIFF
--- a/ruby/lib/minitest/queue/error_report.rb
+++ b/ruby/lib/minitest/queue/error_report.rb
@@ -70,6 +70,10 @@ module Minitest
         @data[:test_line]
       end
 
+      def error_message
+        @data[:error_message]
+      end
+
       def to_h
         @data
       end

--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -29,6 +29,7 @@ module Minitest
           test_name: test.name,
           test_suite: test.klass,
           error_class: test.failure.exception.class.name,
+          error_message: test.failure.exception.message,
           output: to_s,
         }
       end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -524,6 +524,7 @@ module Integration
           error_class: "Minitest::Assertion",
           test_name: "test_bar",
           test_suite: "ATest",
+          error_message: "Expected false to be truthy."
         }
 
         assert_includes failure[:test_file], expected[:test_file]
@@ -532,6 +533,7 @@ module Integration
         assert_equal failure[:test_and_module_name], expected[:test_and_module_name]
         assert_equal failure[:test_name], expected[:test_name]
         assert_equal failure[:error_class], expected[:error_class]
+        assert_equal failure[:error_message], expected[:error_message]
       end
     end
 


### PR DESCRIPTION
This will make it easier to navigate the failures of the stabilization builds of the test oversight service.

This is my first PR to ci-queue so 

![image](https://user-images.githubusercontent.com/3799140/89208059-97bf9980-d5b3-11ea-84b7-68d26b2ffdf6.png)

Part of https://github.com/Shopify/test-infra/issues/411

