### PR TITLE
Queue init timeout

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -8,6 +8,7 @@ module CI
       attr_accessor :max_test_failed
       attr_reader :circuit_breakers
       attr_writer :seed, :build_id
+      attr_writer :queue_init_timeout
 
       class << self
         def from_env(env)
@@ -32,7 +33,8 @@ module CI
         timeout: 30, build_id: nil, worker_id: nil, max_requeues: 0, requeue_tolerance: 0,
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
-        max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil
+        max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil,
+        queue_init_timeout: nil
       )
         @build_id = build_id
         @circuit_breakers = [CircuitBreaker::Disabled]
@@ -48,10 +50,15 @@ module CI
         @seed = seed
         @statsd_endpoint = statsd_endpoint
         @timeout = timeout
+        @queue_init_timeout = queue_init_timeout
         @track_test_duration = track_test_duration
         @worker_id = worker_id
         self.max_consecutive_failures = max_consecutive_failures
         self.max_duration = max_duration
+      end
+
+      def queue_init_timeout
+        @queue_init_timeout || timeout
       end
 
       def max_consecutive_failures=(max)

--- a/ruby/lib/ci/queue/redis/supervisor.rb
+++ b/ruby/lib/ci/queue/redis/supervisor.rb
@@ -8,7 +8,7 @@ module CI
         end
 
         def total
-          wait_for_master(timeout: config.timeout)
+          wait_for_master(timeout: config.queue_init_timeout)
           redis.get(key('total')).to_i
         end
 
@@ -17,7 +17,7 @@ module CI
         end
 
         def wait_for_workers
-          return false unless wait_for_master(timeout: config.timeout)
+          wait_for_master(timeout: config.queue_init_timeout)
 
           yield if block_given?
 

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.20.6'
+    VERSION = '0.20.7'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -361,6 +361,15 @@ module Minitest
           end
 
           help = <<~EOS
+            Specify a timeout to elect the leader and populate the queue.
+            Defaults to the value set for --timeout.
+          EOS
+          opts.separator ""
+          opts.on('--queue-init-timeout TIMEOUT', Float, help) do |timeout|
+            queue_config.queue_init_timeout = timeout
+          end
+
+          help = <<~EOS
             Specify $LOAD_PATH directory, similar to Ruby's -I
           EOS
           opts.separator ""

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -352,7 +352,7 @@ module Minitest
 
           help = <<~EOS
             Specify a timeout after which if a test haven't completed, it will be picked up by another worker.
-            It is very important to set this vlaue higher than the slowest test in the suite, otherwise performance will be impacted.
+            It is very important to set this value higher than the slowest test in the suite, otherwise performance will be impacted.
             Defaults to 30 seconds.
           EOS
           opts.separator ""

--- a/ruby/test/ci/queue/configuration_test.rb
+++ b/ruby/test/ci/queue/configuration_test.rb
@@ -79,5 +79,26 @@ module CI::Queue
       flaky_tests = Configuration.load_flaky_tests('/tmp/does-not-exist')
       assert_empty flaky_tests
     end
+
+    def test_queue_init_timeout_unset
+      config = Configuration.from_env({})
+
+      assert_equal config.timeout, config.queue_init_timeout
+    end
+
+    def test_queue_init_timeout_unset_timeout_set
+      config = Configuration.from_env({})
+      config.timeout = 120
+
+      assert_equal config.timeout, config.queue_init_timeout
+    end
+
+    def test_queue_init_timeout_set
+      config = Configuration.from_env({})
+      config.queue_init_timeout = 45
+      config.timeout = 120
+
+      assert_equal 45, config.queue_init_timeout
+    end
   end
 end


### PR DESCRIPTION
At the moment the `--timeout` argument has more than one meaning. This PR adds a timeout specific to the initialization of the queue.

The new argument is backward compatible, not requiring a major version update.
