### PR TITLE
Gracefully handle invalid JUnit XML files

### DIFF
--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.20.6'
+    VERSION = '0.20.7'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -7,6 +7,8 @@ require 'fileutils'
 module Minitest
   module Queue
     class JUnitReporter < Minitest::Reporters::BaseReporter
+      include ::CI::Queue::OutputHelpers
+
       def initialize(report_path = 'log/junit.xml', options = {})
         super({})
         @report_path = File.absolute_path(report_path)
@@ -76,6 +78,8 @@ module Minitest
 
           testcase = testsuite.add_element('testcase', attributes)
           add_xml_message_for(testcase, test) unless test.passed?
+        rescue REXML::ParseException, RuntimeError => error
+          step(red("Skipping adding '#{suite}##{test.name}' to JUnit report: #{error.message}"))
         end
       end
 

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -147,6 +147,22 @@ module Minitest::Reporters
       XML
     end
 
+    def test_gracefully_handles_invalid_xml_files
+      capture_io do
+        reporter = Minitest::Queue::JUnitReporter.new
+        reporter.record(result("test_\bname", failure: "failure"))
+
+        assert_equal <<~XML, generate_xml(reporter)
+          <?xml version="1.1" encoding="UTF-8"?>
+          <testsuites>
+            <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="0" failures="1" errors="0" tests="1" assertions="1" time="0.12">
+              <testcase/>
+            </testsuite>
+          </testsuites>
+        XML
+      end
+    end
+
     private
 
     def generate_xml(junitxml)


### PR DESCRIPTION
This adds some rescue to gracefully handle invalid JUnit XML files.

AFAIK we only use the JUnit files for annotation so we can safely just ignore an invalid character.

We already do a [similar thing in shopify-build](https://github.com/Shopify/shopify-build/blob/4b6765680d064b14dc23c48c2f6ccd49d9885365/lib/shopify_build/artifact_export_directory.rb#L107).

https://buildkite.com/shopify/shopify-selective-tests/builds/303594#0717c9a3-c2d8-4031-92b6-34c014a40320/153-154