### PR TITLE
Exit 1 when there is an uninitialized constant

### DIFF
--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -398,7 +398,7 @@ module RSpec
           end
         end
 
-        return 0 if @world.non_example_failure
+        return 1 if @world.non_example_failure
         success ? 0 : @configuration.failure_exit_code
       end
 

--- a/ruby/test/fixtures/uninitialized_constant_suite/.rspec
+++ b/ruby/test/fixtures/uninitialized_constant_suite/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/ruby/test/fixtures/uninitialized_constant_suite/spec/dummy_spec.rb
+++ b/ruby/test/fixtures/uninitialized_constant_suite/spec/dummy_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+RSpec.describe NonExistingObject do
+  it "won't run" do
+    expect(1 + 1).to be == 2
+  end
+end

--- a/ruby/test/fixtures/uninitialized_constant_suite/spec/spec_helper.rb
+++ b/ruby/test/fixtures/uninitialized_constant_suite/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+RSpec.configure do |config|
+  config.backtrace_inclusion_patterns << %r{/test/fixtures/}
+end


### PR DESCRIPTION
We are currently exiting with 0 when there is an error such as
uninitialized constant. Buildkite and probably other CI systems will
then consider this status as successful and the suite will only fail
when the aggregate of the executed tests is checked.
With this change the individual steps will also fail.

This also changes the behavior of the before-suite failures which will
now start exiting with 1, see https://github.com/Shopify/ci-queue/pull/73/files.