### PR TITLE
Add time details about test runs

### DIFF
--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.20.9'
+    VERSION = '0.21.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/lib/minitest/queue/test_data.rb
+++ b/ruby/lib/minitest/queue/test_data.rb
@@ -52,6 +52,14 @@ module Minitest
         @test.time
       end
 
+      def test_start_timestamp
+        @test.start_timestamp
+      end
+
+      def test_finish_timestamp
+        @test.finish_timestamp
+      end
+
       def test_file_path
         path = @test.source_location.first
         begin
@@ -107,6 +115,8 @@ module Minitest
           test_retried: test_retried,
           test_assertions: test_assertions,
           test_duration: test_duration,
+          test_start_timestamp: test_start_timestamp,
+          test_finish_timestamp: test_finish_timestamp,
           test_file_path: test_file_path,
           test_file_line_number: test_file_line_number,
           error_class: error_class,

--- a/ruby/test/fixtures/test/time_test.rb
+++ b/ruby/test/fixtures/test/time_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class TimeTest < Minitest::Test
+  def test_foo
+    sleep(1)
+    assert true
+  end
+end


### PR DESCRIPTION
Store timestamps related to when a test begun running and when it finished.

We currently have access to the overall time the test took, but not at what point in time the test was run.