### PR TITLE
Fix failures when running the full ruby test suite locally

### DIFF
--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'ci/queue/static'
+require 'set'
 
 module CI
   module Queue


### PR DESCRIPTION
When running the test suite locally I was seeing two failures with the following message: `undefined method 'to_set' for []:Array (NoMethodError)`.

The [documentation](https://ruby-doc.org/stdlib-2.6.5/libdoc/set/rdoc/Enumerable.html) mentions that `require 'set'` is necessary prior to using the `to_set` method.