### PR TITLE
Don't crash on missing result

### DIFF
--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.21.0'
+    VERSION = '0.21.1'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -168,6 +168,8 @@ module Minitest
         result = yield
         result
       ensure
+        return unless result
+
         result.start_timestamp = start_timestamp
         result.finish_timestamp = current_timestamp
       end


### PR DESCRIPTION
I saw these errors on a branch. It doesn't seem to happen all the time though.

![image](https://user-images.githubusercontent.com/3799140/134492953-22150d8e-6ccd-4440-a220-4dc11aa2cced.png)
