### PR TITLE
Use attr_accessor to define both reader/writer

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -189,11 +189,7 @@ module Minitest
       end
     end
 
-    attr_reader :queue
-
-    def queue=(queue)
-      @queue = queue
-    end
+    attr_accessor :queue
 
     def queue_reporters=(reporters)
       @queue_reporters ||= []


### PR DESCRIPTION
Seems changes in be041edc3f20618c745156979475fd9711635885 removed other stuff in the writer so we can just combine these two back.