### PR TITLE
Fix NoMethodError when result is not defined

### DIFF
--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.21.0'
+    VERSION = '0.21.1'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -168,8 +168,10 @@ module Minitest
         result = yield
         result
       ensure
-        result.start_timestamp = start_timestamp
-        result.finish_timestamp = current_timestamp
+        if result
+          result.start_timestamp = start_timestamp
+          result.finish_timestamp = current_timestamp
+        end
       end
 
       def run


### PR DESCRIPTION
When the ensure block is called and the result isn't defined, a NoMethodError is thrown.