### PR TITLE
Exit early if all workers die

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -8,7 +8,7 @@ module CI
       attr_accessor :max_test_failed, :redis_ttl
       attr_reader :circuit_breakers
       attr_writer :seed, :build_id
-      attr_writer :queue_init_timeout
+      attr_writer :queue_init_timeout, :report_timeout, :inactive_workers_timeout
 
       class << self
         def from_env(env)
@@ -35,7 +35,7 @@ module CI
         namespace: nil, seed: nil, flaky_tests: [], statsd_endpoint: nil, max_consecutive_failures: nil,
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
         max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil,
-        queue_init_timeout: nil, redis_ttl: 8 * 60 * 60
+        queue_init_timeout: nil, redis_ttl: 8 * 60 * 60, report_timeout: nil, inactive_workers_timeout: nil
       )
         @build_id = build_id
         @circuit_breakers = [CircuitBreaker::Disabled]
@@ -57,10 +57,20 @@ module CI
         self.max_consecutive_failures = max_consecutive_failures
         self.max_duration = max_duration
         @redis_ttl = redis_ttl
+        @report_timeout = report_timeout
+        @inactive_workers_timeout = inactive_workers_timeout
       end
 
       def queue_init_timeout
         @queue_init_timeout || timeout
+      end
+
+      def report_timeout
+        @report_timeout || timeout
+      end
+
+      def inactive_workers_timeout
+        @inactive_workers_timeout || timeout
       end
 
       def max_consecutive_failures=(max)

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -368,6 +368,24 @@ module Minitest
           end
 
           help = <<~EOS
+            Specify a timeout after which the report command will fail if not all tests have been processed.
+            Defaults to the value set for --timeout.
+          EOS
+          opts.separator ""
+          opts.on('--report-timeout TIMEOUT', Float, help) do |timeout|
+            queue_config.report_timeout = timeout
+          end
+
+          help = <<~EOS
+            Specify a timeout after the report will fail if all workers are inactive (e.g. died).
+            Defaults to the value set for --timeout.
+          EOS
+          opts.separator ""
+          opts.on('--inactive-workers-timeout TIMEOUT', Float, help) do |timeout|
+            queue_config.inactive_workers_timeout = timeout
+          end
+
+          help = <<~EOS
             Specify a timeout to elect the leader and populate the queue.
             Defaults to the value set for --timeout.
           EOS

--- a/ruby/test/ci/queue/configuration_test.rb
+++ b/ruby/test/ci/queue/configuration_test.rb
@@ -112,5 +112,21 @@ module CI::Queue
 
       assert_equal 45, config.queue_init_timeout
     end
+
+    def test_report_timeout_unset_timeout_set
+      config = Configuration.from_env({})
+      config.timeout = 120
+
+      assert_equal config.timeout, config.report_timeout
+    end
+
+    def test_report_timeout_set
+      config = Configuration.from_env({})
+      config.report_timeout = 45
+      config.timeout = 120
+
+      assert_equal 45, config.report_timeout
+    end
+
   end
 end

--- a/ruby/test/ci/queue/redis_supervisor_test.rb
+++ b/ruby/test/ci/queue/redis_supervisor_test.rb
@@ -39,6 +39,18 @@ class CI::Queue::Redis::SupervisorTest < Minitest::Test
     assert_equal true, workers_done
   end
 
+  def test_wait_for_workers_timeout
+    @supervisor = supervisor(timeout: 10, queue_init_timeout: 0.1)
+    io = nil
+    thread = Thread.start do
+      io = capture_io { @supervisor.wait_for_workers }
+    end
+    thread.wakeup
+    worker(1)
+    thread.join
+    assert_includes io, "Aborting, it seems all workers died.\n"
+  end
+
   def test_num_workers
     assert_equal 0, @supervisor.workers_count
     worker(1)
@@ -58,10 +70,14 @@ class CI::Queue::Redis::SupervisorTest < Minitest::Test
     ).populate(SharedQueueAssertions::TEST_LIST)
   end
 
-  def supervisor
+  def supervisor(timeout: 30, queue_init_timeout: nil)
     CI::Queue::Redis::Supervisor.new(
       @redis_url,
-      CI::Queue::Configuration.new(build_id: '42'),
+      CI::Queue::Configuration.new(
+        build_id: '42',
+        timeout: timeout,
+        queue_init_timeout: queue_init_timeout
+      ),
     )
   end
 end


### PR DESCRIPTION
We frequently have the case that all workers after setup but we still wait ~30 min for all workers to finish. We should check if there are any workers left and if not exit early.

https://buildkite.com/shopify/shopify-selective-tests/builds/752110#0181f401-8546-447f-93c1-6863d019b5d9
https://buildkite.com/shopify/shopify-selective-tests/builds/751666#0181f338-af0f-4fb0-9a59-37ce1aa077e8