### PR TITLE
Upgrade python and libs to something available in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,11 +44,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Python 2.7, 3.6, 3.7
+      - name: Install Python 2.7, 3.7, 3.11
         run: |
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get -qq update
-          sudo apt-get install -y python2.7 python3.6 python3.7
+          sudo apt-get install -y python2.7 python3.7{,-distutils} python3.11
           sudo pip install autopep8
       - name: Run Python tests
         run: |

--- a/bin/before-install
+++ b/bin/before-install
@@ -11,7 +11,7 @@ case ENV['SUITE']
 when 'python'
   Dir.chdir('python/') do
     run('sudo', 'pip', 'install', '-U', 'pip')
-    run('sudo', 'pip', 'install', 'setuptools==33.1.1')
+    run('sudo', 'pip', 'install', 'setuptools==67.6.1')
     run('pip', '--version')
     run('sudo', 'make', 'install')
   end

--- a/python/Makefile
+++ b/python/Makefile
@@ -22,7 +22,7 @@ lint:
 autolint: autopep8 lint
 
 run_tests: clean
-	tox -e py27,py36,py37 -- --durations=10 -vv tests
+	tox -e py27,py37,py311 -- --durations=10 -vv tests
 
 test: autopep8 run_tests
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py27,py36,py37
+envlist = py27,py37,py311
 
 [testenv]
 commands = pytest {posargs:-vv}

--- a/python/setup.py
+++ b/python/setup.py
@@ -37,7 +37,7 @@ setuplib.setup(
     packages=['ciqueue', 'ciqueue._pytest'],
     install_requires=[
         'dill>=0.2.7',
-        'pytest>=2.7,<=3.5.0',
+        'pytest>=2.7',
         'redis>=2.10.5',
         'tblib>=1.3.2',
         'uritools>=2.0.0',


### PR DESCRIPTION
Trade 3.6 for 3.11

> - Ubuntu 22.04 (jammy) Python3.7 - Python3.9, Python3.11
> - Note: Python2.7 (all), Python 3.6 (bionic), Python 3.8 (focal), Python 3.10 (jammy) are not provided by deadsnakes as upstream ubuntu provides those packages.

install distutils with 3.7 to avoid
  ModuleNotFoundError: No module named 'distutils.cmd'

let pytest be upgraded so 3.11 avoids
    from collections import Sequence

Upgrade setuptools to avoid
  AttributeError: module 'collections' has no attribute 'MutableMapping'