### PR TITLE
Run ruby test suite against truffleruby in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,9 @@ jobs:
         ruby: [ '2.7', '3.0', '3.1', '3.2' ]
     steps:
       - uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+          sudo apt-get install libsnappy-dev
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby:
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - 'truffleruby'
     steps:
       - uses: actions/checkout@v2
       - name: Install deps

--- a/.spin/packages.yml
+++ b/.spin/packages.yml
@@ -1,0 +1,1 @@
+- libsnappy-dev

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,8 @@
+---
+# This file is for Shopify employees development environment.
+# If you are an external contributor you don't have to bother with it.
+
+name: ci-queue
+
+up:
+  - snappy

--- a/ruby/test/integration/grind_redis_test.rb
+++ b/ruby/test/integration/grind_redis_test.rb
@@ -97,7 +97,7 @@ module Integration
 
     def test_grind_max_time
       grind_count = 1000000
-      timeout = RUBY_ENGINE == "truffleruby" ? 4 : 1
+      timeout = RUBY_ENGINE == "truffleruby" ? 10 : 1
 
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       _, err = capture_subprocess_io do

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -520,7 +520,8 @@ module Integration
                     .sort_by { |h| "#{h[:test_id]}##{h[:test_index]}" }
                     .first
 
-      assert_in_delta start_time.to_i, failure[:test_start_timestamp], 5
+      start_delta = RUBY_ENGINE == "truffleruby" ? 15 : 5
+      assert_in_delta start_time.to_i, failure[:test_start_timestamp], start_delta, "start time"
       assert_in_delta end_time.to_i, failure[:test_finish_timestamp], 5
       assert failure[:test_finish_timestamp] > failure[:test_start_timestamp]
     end


### PR DESCRIPTION
- Install libsnappy-dev as the gem will use the system lib if present.  When not present it installs a vendored one which breaks on truffleruby
- Increase time for subprocess startup by 10s for TruffleRuby
- Add trufflerubyto CI