### PR TITLE
Fix leakbot command instruction in Spin

### DIFF
--- a/ruby/lib/ci/queue/common.rb
+++ b/ruby/lib/ci/queue/common.rb
@@ -7,6 +7,10 @@ module CI
       # to override in classes including this module
       CONNECTION_ERRORS = [].freeze
 
+      def distributed?
+        raise NotImplementedError
+      end
+
       def retrying?
         false
       end

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -21,6 +21,10 @@ module CI
           super(redis, config)
         end
 
+        def distributed?
+          true
+        end
+
         def populate(tests, random: Random.new)
           @index = tests.map { |t| [t.id, t] }.to_h
           tests = Queue.shuffle(tests, random)

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -22,6 +22,10 @@ module CI
         @total = tests.size
       end
 
+      def distributed?
+        false
+      end
+
       def build
         @build ||= BuildRecord.new(self)
       end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -253,8 +253,10 @@ module Minitest
       attr_accessor :queue, :queue_url, :grind_list, :grind_count, :load_paths
 
       def require_worker_id!
-        invalid_usage!("build-id couldn't be inferred from ENV and wasn't set via --build") unless queue_config.build_id
-        invalid_usage!("worker-id couldn't be inferred from ENV and wasn't set via --worker") unless queue_config.worker_id
+        if queue.distributed?
+          invalid_usage!("build-id couldn't be inferred from ENV and wasn't set via --build") unless queue_config.build_id
+          invalid_usage!("worker-id couldn't be inferred from ENV and wasn't set via --worker") unless queue_config.worker_id
+        end
       end
 
       def display_warnings(build)


### PR DESCRIPTION
Avoid asking for `worker` and `build` while running a leakbot reproducing command in Spin.

Resolves: Shopify/shopify#421914