### PR TITLE
Make seconds fraction optional when normalizing test output

### DIFF
--- a/ruby/test/support/output_test_helpers.rb
+++ b/ruby/test/support/output_test_helpers.rb
@@ -17,7 +17,7 @@ module OutputTestHelpers
   end
 
   def freeze_timing(output)
-    output.to_s.gsub(/\d+\.\d+s/, 'X.XXs').gsub(/ \d+\.\d+ seconds /, ' X.XXXXX seconds ')
+    output.to_s.gsub(/\d+\.\d+s/, 'X.XXs').gsub(/ \d+(\.\d+)? seconds /, ' X.XXXXX seconds ')
   end
 
   def freeze_seed(output)


### PR DESCRIPTION
Rspec's report will not display the fraction is it's close enough to zero:

```
irb(main):011:0> RSpec::Core::Formatters::Helpers::format_seconds(3.01)
=> "3.01"
irb(main):012:0> RSpec::Core::Formatters::Helpers::format_seconds(3.001)
=> "3"
```

https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/formatters/helpers.rb#L60-L65

I saw a test flake like this:

```
Integration::RSpecRedisTest
  test_redis_runner_retry                                         PASS (32.70s)
  test_retry_report                                               FAIL (48.07s)
        --- expected
        +++ actual
        @@ -3,7 +3,7 @@
         Randomized with seed 123
         .

        -Finished in X.XXXXX seconds (files took X.XXXXX seconds to load)
        +Finished in X.XXXXX seconds (files took 3 seconds to load)
         1 example, 0 failures

         Randomized with seed 123
        /Users/rwstauner/src/github.com/Shopify/ci-queue/ruby/test/integration/rspec_redis_test.rb:227:in `test_retry_report'

  test_report                                                     PASS (32.39s)
```