### PR TITLE
Allow specifying files to test with 'dev test'

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -6,7 +6,9 @@ require 'ci/queue/version'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.libs << 'lib'
-  t.test_files = FileList['test/**/*_test.rb'] - FileList['test/fixtures/**/*_test.rb']
+  selected_files = ENV["TEST_FILES"].to_s.strip.split(/\s+/)
+  selected_files = nil if selected_files.empty?
+  t.test_files = selected_files || FileList['test/**/*_test.rb'] - FileList['test/fixtures/**/*_test.rb']
 end
 
 task :default => :test

--- a/ruby/dev.yml
+++ b/ruby/dev.yml
@@ -8,4 +8,4 @@ up:
 - isogun
 
 commands:
-  test: REDIS_URL=${REDIS_URL:-redis://ci-queue.railgun/0} bundle exec rake test
+  test: REDIS_URL=${REDIS_URL:-redis://ci-queue.railgun/0} bundle exec rake test TEST_FILES="$*"


### PR DESCRIPTION
The whole suite can take a while, it's nice to be able to run specific files when you're debugging something.

Test all: `dev test`
Test specific files: `dev test test/minitest/reporters/*`