### PR TITLE
Make it easier to identify why the grind test might be failing and increase timeout for truffleruby

### DIFF
--- a/ruby/test/integration/grind_redis_test.rb
+++ b/ruby/test/integration/grind_redis_test.rb
@@ -97,7 +97,7 @@ module Integration
 
     def test_grind_max_time
       grind_count = 1000000
-      timeout = 1
+      timeout = RUBY_ENGINE == "truffleruby" ? 4 : 1
 
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       _, err = capture_subprocess_io do


### PR DESCRIPTION
This adds some additional checks and messages to help identify why the test is failing and what might help.

When I first ran the suite with TruffleRuby I was seeing

```
This worker is exiting early because it reached its timeout of 1 seconds
  test_grind_max_time                                            ERROR (8.89s)
Minitest::UnexpectedError:         NoMethodError: undefined method `scan' for nil:NilClass
            /home/spin/src/github.com/Shopify/ci-queue/ruby/test/integration/grind_redis_test.rb:131:in `test_grind_max_time'
```

This PR:
- captures that STDERR line
- asserts that it is present (to ensure that the subprocess exited for the timeout as expected)
- protects against nil error with a few more assertions
- adds a message about what might be happening and what might help
- measures the time the process took for when its useful to know (based on ruby versions i can get a range including ~2s, ~7s, ~17s)
- increases the timeout for when using truffleruby to something that will allow the subprocess to get started so that the tests pass