### PR TITLE
Accept -v/--verbose option and include the usual reporter

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -531,6 +531,10 @@ module Minitest
             queue.config.redis_ttl = time
           end
 
+          opts.on("-v", "--verbose", "Verbose. Show progress processing files.") do
+            (Minitest::Reporters.reporters ||= []) << Minitest::Reporters::DefaultReporter.new(verbose: true)
+          end
+
           opts.separator ""
           opts.separator "    retry: Replays a previous run in the same order."
 


### PR DESCRIPTION
By default ci-queue overwrites the reporters array.

Minitest's verbose option is only utilized by it's own default reporter and the default reporter that minitest-reporters replaces it with, so the simplest thing to do is to simply include one of those.

The included `LocalRequeueReporter` also displays a summary line, so in this case you get 2 summary lines
<img width="1368" alt="image" src="https://github.com/Shopify/ci-queue/assets/142719/39581613-2a8b-4da7-aed2-472cec339f29">

However the `DefaultReporter` has a significant amount of logic in it
and the `LocalRequeueReporter` has other functionality
so choosing one over the other doesn't seem right,
nor does it feel worthwhile to recreate the logic.

We could change the LocalRequeueReporter to inherit from DefaultReporter (instead of BaseReporter) and pass our verbose option to that.
We could then remove this code, since the default reporter includes it (minus the color differentiation)
https://github.com/Shopify/ci-queue/blob/7754f53ff84e4dac486741102ed355ea07b1564f/ruby/lib/minitest/queue/local_requeue_reporter.rb#L26-L33

and it would address https://github.com/Shopify/ci-queue/issues/70
but then there is also a question of "should we detect the presence of other reporters before including this one"?

What do you think?
Include an additional reporter, or inherit from the default one?
If we don't care about having the default output always included, the patch itself is simple... unless the placement of the `reopen_previous_step` output is important.
https://github.com/Shopify/ci-queue/blob/cf0d3351f9a6da2358dfc74f9894b8b4a9e9e183/ruby/lib/minitest/queue/local_requeue_reporter.rb#L25
