### PR TITLE
Support multiple -I args

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -414,7 +414,7 @@ module Minitest
           EOS
           opts.separator ""
           opts.on('-IPATHS', help) do |paths|
-            self.load_paths = paths
+            self.load_paths = [load_paths, paths].compact.join(':')
           end
 
           help = <<~EOS

--- a/ruby/test/minitest/queue/runner_test.rb
+++ b/ruby/test/minitest/queue/runner_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'minitest/queue/runner'
+require 'test_helper'
+
+module Minitest::Queue
+  class RunnerTest < Minitest::Test
+    def test_multiple_load_paths
+      runner = Runner.new(["-Ilib:test", "-Ielse"])
+      assert_equal("lib:test:else", runner.send(:load_paths))
+    end
+  end
+end


### PR DESCRIPTION
closes #157

Later code simply splits the arg on `:` so the simplest thing to do is just concatenate on that.

https://github.com/Shopify/ci-queue/blob/55e662a4071e6f1dfef53a7bbe9b080f2a49db75/ruby/lib/minitest/queue/runner.rb#L296-L297
https://github.com/Shopify/ci-queue/blob/55e662a4071e6f1dfef53a7bbe9b080f2a49db75/ruby/lib/minitest/queue/runner.rb#L174
