### PR TITLE
Update dev.yml for isogun deprecation

### DIFF
--- a/ruby/dev.yml
+++ b/ruby/dev.yml
@@ -5,7 +5,7 @@ name: ci-queue
 up:
 - ruby: 2.6.5
 - bundler
-- isogun
+- redis
 
 commands:
   test: REDIS_URL=${REDIS_URL:-redis://ci-queue.railgun/0} bundle exec rake test TEST_FILES="$*"


### PR DESCRIPTION
this avoids a big warning and provides the `$REDIS_*` vars