### PR TITLE
Warn when internal reporters have been removed

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -88,7 +88,34 @@ module Minitest
           load_tests
           populate_queue
         end
+
+        at_exit {
+          verify_reporters!(reporters)
+        }
         # Let minitest's at_exit hook trigger
+      end
+
+      def verify_reporters!(reporters)
+        return unless reporters.any? { |r| !Minitest::Reporters.reporters.include?(r) }
+
+        warn <<~WARNING
+          WARNING!
+
+          ci-queue requires several custom minitest reporters.
+          Please do not overwrite them.
+          If you have a statement in your test suite like this
+
+            Minitest::Reporters.use!(SomeReporter.new)
+
+          you should only run it when other reporters have not been configured
+          to avoid breaking ci-queue's functionality and getting false test summaries.
+
+          Use something like this:
+
+            if Minitest::Reporters.reporters.nil?
+              Minitest::Reporters.use!(SomeReporter.new)
+            end
+        WARNING
       end
 
       def release_command


### PR DESCRIPTION
Without our reporters data will be missing and the report will incorrectly show zeroes for all counts.

```
$ minitest-queue report
Waiting for workers to complete
Ran 7 tests, 0 assertions, 0 failures, 0 errors, 0 skips, 0 requeues in 0.00s (aggregated)
```

The warning explains how it happens and what to do about it.