### PR TITLE
Inherit from DefaultReporter for consistent minitest output

### DIFF
--- a/ruby/lib/minitest/queue/local_requeue_reporter.rb
+++ b/ruby/lib/minitest/queue/local_requeue_reporter.rb
@@ -4,7 +4,7 @@ require 'minitest/reporters'
 
 module Minitest
   module Queue
-    class LocalRequeueReporter < Minitest::Reporters::BaseReporter
+    class LocalRequeueReporter < Minitest::Reporters::DefaultReporter
       include ::CI::Queue::OutputHelpers
       attr_accessor :requeues
 

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -68,7 +68,7 @@ module Minitest
         set_load_path
         Minitest.queue = queue
         reporters = [
-          LocalRequeueReporter.new,
+          LocalRequeueReporter.new(verbose: verbose),
           BuildStatusRecorder.new(build: queue.build),
           JUnitReporter.new,
           TestDataReporter.new(namespace: queue_config&.namespace),
@@ -284,7 +284,7 @@ module Minitest
       private
 
       attr_reader :queue_config, :options, :command, :argv
-      attr_accessor :queue, :queue_url, :grind_list, :grind_count, :load_paths
+      attr_accessor :queue, :queue_url, :grind_list, :grind_count, :load_paths, :verbose
 
       def require_worker_id!
         if queue.distributed?
@@ -575,7 +575,7 @@ module Minitest
           end
 
           opts.on("-v", "--verbose", "Verbose. Show progress processing files.") do
-            (Minitest::Reporters.reporters ||= []) << Minitest::Reporters::DefaultReporter.new(verbose: true)
+            self.verbose = true
           end
 
           opts.separator ""


### PR DESCRIPTION
This is a follow up to #217.

In addition to supporting verbose mode,
inherit from the default reporter
so that we get the failure output by default.

Considering we now discourage using other reporters to avoid breaking functionality (#220)
we probably don't need to be concerned with detecting other reporters.

This closes #70