### PR TITLE
Upgrade activesupport to next major release (5 -> 6)

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ci-queue.gemspec
 gemspec
 
-gem 'activesupport', '~> 5.2.0'
+gem 'activesupport', '~> 6.1.7'


### PR DESCRIPTION
activesupport 5.x requires tzinfo 1.x which requires thread_safe which has been deprecated in favor of concurrent-ruby.

7 is the latest but it requires ruby 2.7 and we are using 2.6.

I started looking into this when I noticed this output when testing on truffleruby:
> $ bundle exec rake
> ThreadSafe: unsupported Ruby engine, using a fully synchronized ThreadSafe::Cache implementation

concurrent-ruby specifically supports truffleruby.