### PR TITLE
Unlock Active Support

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ci-queue.gemspec
 gemspec
 
-gem 'activesupport', '~> 6.1.7'
+gem 'activesupport'


### PR DESCRIPTION
Followup: https://github.com/Shopify/ci-queue/pull/223

It's only used in test for the time helpers (e.g. like TimeCop)

There is no point locking to a specific version.