### PR TITLE
Fix Python tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
 
     services:
       redis:
@@ -44,11 +46,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Python 2.7, 3.6, 3.7
+      - name: Install Python ${{ matrix.python }}
         run: |
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get -qq update
-          sudo apt-get install -y python2.7 python3.6 python3.7
+          sudo apt-get install -y python${{ matrix.python }} python${{ matrix.python }}-distutils
           sudo pip install autopep8
       - name: Run Python tests
         run: |
@@ -56,5 +58,6 @@ jobs:
           bin/test
         env:
           SUITE: python
+          PYTHON_VERSION: ${{ matrix.python }}
           REDIS_HOST: localhost
           REDIS_PORT: 6379

--- a/bin/before-install
+++ b/bin/before-install
@@ -11,7 +11,7 @@ case ENV['SUITE']
 when 'python'
   Dir.chdir('python/') do
     run('sudo', 'pip', 'install', '-U', 'pip')
-    run('sudo', 'pip', 'install', 'setuptools==33.1.1')
+    run('sudo', 'pip', 'install', 'setuptools==68.0.0')
     run('pip', '--version')
     run('sudo', 'make', 'install')
   end

--- a/bin/test
+++ b/bin/test
@@ -9,8 +9,14 @@ end
 
 case ENV['SUITE']
 when 'python'
+  environment = { 'PYTHONPATH' => '.'}
+  python_version = ENV['PYTHON_VERSION']
+  unless python_version.nil?
+    tox_py_env = "py" + python_version.split('.')[..1].join('')
+    environment['TOX_ENV'] = tox_py_env
+  end
   Dir.chdir('python/') do
-    run({ 'PYTHONPATH' => '.' }, 'sudo', 'make', 'test')
+    run(environment, 'sudo', '--preserve-env', 'make', 'test')
   end
 when 'ruby'
   Dir.chdir('ruby/') do

--- a/python/Makefile
+++ b/python/Makefile
@@ -4,6 +4,8 @@ python_files := find . -path '*/.*' -prune -o -name '*.py' -print0
 python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
 python_version_major := $(word 1,${python_version_full})
 
+TOX_ENV ?= py37,py38,py39,py310,py311
+
 all: test
 
 clean:
@@ -22,7 +24,7 @@ lint:
 autolint: autopep8 lint
 
 run_tests: clean
-	tox -e py27,py36,py37 -- --durations=10 -vv tests
+	tox -e ${TOX_ENV} -- --durations=10 -vv tests
 
 test: autopep8 run_tests
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py27,py36,py37
+envlist = py37,py38,py39,py310,py311
 
 [testenv]
 commands = pytest {posargs:-vv}

--- a/python/setup.py
+++ b/python/setup.py
@@ -37,7 +37,7 @@ setuplib.setup(
     packages=['ciqueue', 'ciqueue._pytest'],
     install_requires=[
         'dill>=0.2.7',
-        'pytest>=2.7,<=3.5.0',
+        'pytest>=2.7,<7',
         'redis>=2.10.5',
         'tblib>=1.3.2',
         'uritools>=2.0.0',
@@ -45,9 +45,9 @@ setuplib.setup(
     ],
     extras_require={
         'test': [
-            'tox==3.21.0',
+            'tox==4.6.4',
             'shopify_python==0.5.3',
-            'pycodestyle == 2.4.0',
+            'pycodestyle==2.10.0',
         ]
     },
     package_data={'': get_lua_scripts()},

--- a/python/tests/test_pytest.py
+++ b/python/tests/test_pytest.py
@@ -6,7 +6,7 @@ import redis
 
 
 def expected_messages(output):
-    assert '= 4 failed, 2 passed, 1 skipped, 1 xpassed, 6 error in' in output, output
+    assert '= 4 failed, 2 passed, 1 skipped, 1 xpassed, 6 errors in' in output, output
     assert ('integrations/pytest/test_all.py:27: skipping test message' in output
             or 'integrations/pytest/test_all.py:28: skipping test message' in output), output
 
@@ -57,15 +57,15 @@ class TestIntegration(object):
             .format(queue, xml_file, filename)
 
         output = check_output(cmd.format(queue, filename))
-        assert '= 4 failed, 2 passed, 4 skipped, 1 xpassed, 6 error in' in output, output
+        assert '= 4 failed, 2 passed, 4 skipped, 1 xpassed, 6 errors in' in output, output
         assert ('integrations/pytest/test_all.py:27: skipping test message' in output
                 or 'integrations/pytest/test_all.py:28: skipping test message' in output), output
         assert ' WILL_RETRY ' in output, output
 
         xml = open(xml_file).read()
-        assert xml.count('/failure') == 4
+        assert xml.count('/failure') == 5
         assert xml.count('/skipped') == 4
-        assert xml.count('/error') == 6
+        assert xml.count('/error') == 7
 
         expected_messages(check_output(report_cmd.format(queue, filename)))
         xml = open(xml_file).read()


### PR DESCRIPTION
* Drop end-of-life Python versions bellow 3.7 (Python 3.7 is also end of life, but let's keep it for backward compatibility)
* Use Gitlab CI matrix for installation and test Python versions in parallel (similar to Ruby). Make sure tox runs only selected Python version
