### PR TITLE
Add shutdown to Static and File queues, and fix some tests

### DIFF
--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -20,6 +20,11 @@ module CI
         @config = config
         @progress = 0
         @total = tests.size
+        @shutdown = false
+      end
+
+      def shutdown!
+        @shutdown = true
       end
 
       def distributed?
@@ -64,7 +69,7 @@ module CI
       end
 
       def poll
-        while config.circuit_breakers.none?(&:open?) && !max_test_failed? && test = @queue.shift
+        while !@shutdown && config.circuit_breakers.none?(&:open?) && !max_test_failed? && test = @queue.shift
           yield index.fetch(test)
         end
       end

--- a/ruby/test/ci/queue/file_test.rb
+++ b/ruby/test/ci/queue/file_test.rb
@@ -6,17 +6,18 @@ class CI::Queue::FileTest < Minitest::Test
 
   TEST_LIST_PATH = '/tmp/queue-test.txt'.freeze
 
+  def test_from_uri
+    log_path = File.expand_path('../../fixtures/test_order.log', __dir__)
+    queue = CI::Queue.from_uri("file://#{log_path}", config)
+    populate(queue)
+    assert_instance_of CI::Queue::File, queue
+    assert_equal %w(ATest#test_foo ATest#test_bar BTest#test_foo BTest#test_bar), queue.to_a.map(&:id)
+  end
+
   private
 
   def build_queue
     File.write(TEST_LIST_PATH, TEST_LIST.map(&:id).join("\n"))
     CI::Queue::File.new(TEST_LIST_PATH, config)
-  end
-
-  def test_from_uri
-    log_path = File.expand_path('../../fixtures/test_order.log', __dir__)
-    queue = CI::Queue.from_uri("file://#{log_path}", config)
-    assert_instance_of CI::Queue::File, queue
-    assert_equal %w(foo bar plop?fizz), queue.to_a
   end
 end

--- a/ruby/test/fixtures/test_order.log
+++ b/ruby/test/fixtures/test_order.log
@@ -1,3 +1,4 @@
-foo
-bar
-plop?fizz
+ATest#test_foo
+ATest#test_bar
+BTest#test_foo
+BTest#test_bar

--- a/ruby/test/support/shared_queue_assertions.rb
+++ b/ruby/test/support/shared_queue_assertions.rb
@@ -77,6 +77,15 @@ module SharedQueueAssertions
     @queue.release!
   end
 
+  def test_shutdown
+    tests = []
+    @queue.poll do |test|
+      tests << test.id
+      @queue.shutdown!
+    end
+    assert_equal %w(ATest#test_foo), tests
+  end
+
   private
 
   def shuffled_test_list


### PR DESCRIPTION
The `Minitest::Queue::Runner` [traps signals](https://github.com/Shopify/ci-queue/blob/f6159e0c79471d999aa31d40637e7a81f1654731/ruby/lib/minitest/queue/runner.rb#L82-L83) and sends `shutdown!` to the queue. However, `shutdown!` doesn't exist doesn't exist on `Static` and `File` type queues, resulting in a printed exception, and a runaway test runner. This PR adds `shutdown!` to those queues.

It also fixes a test in the `File` type that wasn't run by virtue of being `private`.