### PR TITLE
Support `rediss` scheme

### DIFF
--- a/python/ciqueue/_pytest/test_queue.py
+++ b/python/ciqueue/_pytest/test_queue.py
@@ -52,6 +52,8 @@ def parse_redis_args(spec):
         result['socket_connect_timeout'] = int(query['socket_connect_timeout'][0])
     if 'retry_on_timeout' in query:
         result['retry_on_timeout'] = bool(util.strtobool(query['retry_on_timeout'][0] or 'false'))
+    if spec.scheme == "rediss":
+        result['ssl'] = True
 
     return result
 
@@ -62,7 +64,7 @@ def build_queue(queue_url, tests_index=None):
         return ciqueue.Static(spec.path.split(':'))
     elif spec.scheme == 'file':
         return ciqueue.File(spec.path)
-    elif spec.scheme == 'redis':
+    elif spec.scheme == 'redis' or spec.scheme == 'rediss':
         redis_args = parse_redis_args(spec)
         redis_client = redis.StrictRedis(**redis_args)
 

--- a/python/tests/test_test_queue.py
+++ b/python/tests/test_test_queue.py
@@ -1,0 +1,14 @@
+import ciqueue.distributed
+from ciqueue._pytest import test_queue
+
+
+class TestTestQueue:
+    def test_initialise_from_redis_uri(self):
+        queue = test_queue.build_queue('redis://localhost:6379/0?worker=1&build=12345', None)
+        assert type(queue) is ciqueue.distributed.Supervisor
+        assert queue.redis is not None
+
+    def test_initialise_from_rediss_uri(self):
+        queue = test_queue.build_queue('rediss://localhost:6379/0?worker=1&build=12345', None)
+        assert type(queue) is ciqueue.distributed.Supervisor
+        assert queue.redis is not None

--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -43,7 +43,7 @@ module CI
         Static
       when 'file', nil
         File
-      when 'redis'
+      when 'redis', 'rediss'
         require 'ci/queue/redis'
         Redis
       else

--- a/ruby/test/ci/queue/redis_test.rb
+++ b/ruby/test/ci/queue/redis_test.rb
@@ -249,6 +249,16 @@ class CI::Queue::RedisTest < Minitest::Test
     end
   end
 
+  def test_initialise_from_redis_uri
+    queue = CI::Queue.from_uri('redis://localhost:6379/0', config)
+    assert_instance_of CI::Queue::Redis::Worker, queue
+  end
+
+  def test_initialise_from_rediss_uri
+    queue = CI::Queue.from_uri('rediss://localhost:6379/0', config)
+    assert_instance_of CI::Queue::Redis::Worker, queue
+  end
+
   private
 
   def shuffled_test_list


### PR DESCRIPTION
As discussed in #238.

With this commit, `ci-queue` supports `rediss` schemes in addition to `redis`.

Testing is kept simple: Check if both Ruby and Python proper initialize the queue with both scheme variations.