### PR TITLE
Update error_class value in FailureFormatter

### DIFF
--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -28,7 +28,7 @@ module Minitest
           test_and_module_name: "#{test.klass}##{test.name}",
           test_name: test.name,
           test_suite: test.klass,
-          error_class: test.failure.exception.class.name,
+          error_class: test.failure.error.class.name,
           output: to_s,
         }
       end


### PR DESCRIPTION
Relates to https://github.com/Shopify/test-infra/issues/2213

When we run `minitest-queue report`, a test error (not failure) is dumped as `Minitest::UnexpectedError`. As we're working on improving the merge queue build stability, we want to group test errors by their specific error classes and `Minitest::UnexpectedError` doesn't help with that. This PR changes the error class output to be more specific (follow what we have in [TestDataReporter](https://github.com/Shopify/ci-queue/blob/master/ruby/lib/minitest/queue/test_data.rb#L80)).

🎩 https://buildkite.com/shopify/shopify-selective-tests/builds/1257983#018af5d7-9384-4fa4-a653-5e81b3f7225d/9110-9113
Check out the monorail_test_failures_event.json artifact