### PR TITLE
Ruby/Redis: retry connection errors more agressively

### DIFF
--- a/ruby/lib/ci/queue/redis.rb
+++ b/ruby/lib/ci/queue/redis.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+gem 'redis', '>= 5'
 require 'redis'
 require 'ci/queue/redis/build_record'
 require 'ci/queue/redis/base'

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -13,7 +13,12 @@ module CI
 
         def initialize(redis_url, config)
           @redis_url = redis_url
-          @redis = ::Redis.new(url: redis_url)
+          @redis = ::Redis.new(
+            url: redis_url,
+            # Booting a CI worker is costly, so in case of a Redis blip,
+            # it makes sense to retry for a while before giving up.
+            reconnect_attempts: [0, 0, 0.1, 0.5, 1, 3, 5],
+          )
           @config = config
         end
 


### PR DESCRIPTION
Booting a CI worker is costly, so in case of a Redis blip, it makes sense to retry for a while before giving up.