### PR TITLE
Report early exits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3.0-rc1'
           - 'truffleruby'
     steps:
       - uses: actions/checkout@v2

--- a/ruby/dev.yml
+++ b/ruby/dev.yml
@@ -3,7 +3,7 @@
 name: ci-queue
 
 up:
-- ruby: 2.6.5
+- ruby: 3.2.0
 - bundler
 - redis
 

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -5,7 +5,7 @@ module CI
       attr_accessor :timeout, :worker_id, :max_requeues, :grind_count, :failure_file, :export_flaky_tests_file
       attr_accessor :requeue_tolerance, :namespace, :failing_test, :statsd_endpoint
       attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
-      attr_accessor :max_test_failed, :redis_ttl
+      attr_accessor :max_test_failed, :redis_ttl, :warnings_file
       attr_reader :circuit_breakers
       attr_writer :seed, :build_id
       attr_writer :queue_init_timeout, :report_timeout, :inactive_workers_timeout
@@ -36,7 +36,7 @@ module CI
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
         max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil,
         queue_init_timeout: nil, redis_ttl: 8 * 60 * 60, report_timeout: nil, inactive_workers_timeout: nil,
-        export_flaky_tests_file: nil
+        export_flaky_tests_file: nil, warnings_file: nil
       )
         @build_id = build_id
         @circuit_breakers = [CircuitBreaker::Disabled]
@@ -61,6 +61,7 @@ module CI
         @report_timeout = report_timeout
         @inactive_workers_timeout = inactive_workers_timeout
         @export_flaky_tests_file = export_flaky_tests_file
+        @warnings_file = warnings_file
       end
 
       def queue_init_timeout

--- a/ruby/lib/ci/queue/redis/build_record.rb
+++ b/ruby/lib/ci/queue/redis/build_record.rb
@@ -21,6 +21,7 @@ module CI
           redis.hkeys(key('error-reports'))
         end
 
+        TOTAL_KEY = "___total___"
         def requeued_tests
           requeues = redis.hgetall(key('requeues-count'))
           requeues.delete(TOTAL_KEY)

--- a/ruby/lib/ci/queue/redis/build_record.rb
+++ b/ruby/lib/ci/queue/redis/build_record.rb
@@ -21,6 +21,12 @@ module CI
           redis.hkeys(key('error-reports'))
         end
 
+        def requeued_tests
+          requeues = redis.hgetall(key('requeues-count'))
+          requeues.delete(TOTAL_KEY)
+          requeues
+        end
+
         def pop_warnings
           warnings = redis.multi do |transaction|
             transaction.lrange(key('warnings'), 0, -1)

--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -21,10 +21,20 @@ module Minitest
         build.flaky_reports
       end
 
+      def requeued_tests
+        build.requeued_tests
+      end
+
       def report
         puts aggregates
         errors = error_reports
         puts errors
+
+        requeued_tests.to_a.sort.each do |test_id, count|
+          puts yellow("REQUEUE")
+          puts "#{test_id} (requeued #{count} times)"
+          puts ""
+        end
 
         errors.empty?
       end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -230,6 +230,8 @@ module Minitest
             msg = "#{supervisor.size} tests weren't run."
             if supervisor.max_test_failed?
               puts('Encountered too many failed tests. Test run was ended early.')
+              reporter = BuildStatusReporter.new(build: supervisor.build)
+              reporter.report
               abort!(msg)
             else
               abort!(msg)

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -160,9 +160,10 @@ module Integration
       expected = <<~EXPECTED
         Waiting for workers to complete
         Encountered too many failed tests. Test run was ended early.
-        97 tests weren't run.
+        Ran 3 tests, 47 assertions, 3 failures, 0 errors, 0 skips, 44 requeues in X.XXs (aggregated)
       EXPECTED
-      assert_equal expected.strip, normalize(out.lines[0..4].join.strip)
+      assert_equal expected.strip, normalize(out.lines[0..3].join.strip)
+      assert_equal "97 tests weren't run.", normalize(out.lines.last.strip)
     end
 
     def test_circuit_breaker

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -731,37 +731,60 @@ module Integration
       output = normalize(out.lines.last.strip)
       assert_equal 'Ran 11 tests, 8 assertions, 2 failures, 1 errors, 1 skips, 4 requeues in X.XXs', output
 
-      out, err = capture_subprocess_io do
-        system(
-          @exe, 'report',
-          '--queue', @redis_url,
-          '--build', '1',
-          '--timeout', '1',
-          chdir: 'test/fixtures/',
-        )
+      Tempfile.open('warnings') do |warnings_file|
+        out, err = capture_subprocess_io do
+          system(
+            @exe, 'report',
+            '--queue', @redis_url,
+            '--build', '1',
+            '--timeout', '1',
+            '--warnings-file', warnings_file.path,
+            chdir: 'test/fixtures/',
+          )
+        end
+
+        warning = <<~END
+          [WARNING] Atest#test_bar was picked up by another worker because it didn't complete in the allocated 2 seconds.
+          You may want to either optimize this test or bump ci-queue timeout.
+          It's also possible that the worker that was processing it was terminated without being able to report back.
+        END
+
+        warnings_file.rewind
+        assert_equal warning, warnings_file.read
+
+        assert_empty err
+        output = normalize(out)
+        expected_output = <<~END
+          Waiting for workers to complete
+          Ran 7 tests, 8 assertions, 2 failures, 1 errors, 1 skips, 4 requeues in X.XXs (aggregated)
+
+          FAIL ATest#test_bar
+          Expected false to be truthy.
+              test/dummy_test.rb:10:in `test_bar'
+
+          FAIL ATest#test_flaky_fails_retry
+          Expected false to be truthy.
+              test/dummy_test.rb:23:in `test_flaky_fails_retry'
+
+          ERROR BTest#test_bar
+        END
+        assert_includes output, expected_output
+
+        expected_output = <<~END
+          REQUEUE
+          ATest#test_bar (requeued 1 times)
+
+          REQUEUE
+          ATest#test_flaky (requeued 1 times)
+
+          REQUEUE
+          ATest#test_flaky_fails_retry (requeued 1 times)
+
+          REQUEUE
+          BTest#test_bar (requeued 1 times)
+        END
+        assert_includes output, expected_output
       end
-      assert_empty err
-      output = normalize(out)
-      expected_output = <<~END
-        Waiting for workers to complete
-
-        [WARNING] Atest#test_bar was picked up by another worker because it didn't complete in the allocated 2 seconds.
-        You may want to either optimize this test or bump ci-queue timeout.
-        It's also possible that the worker that was processing it was terminated without being able to report back.
-
-        Ran 7 tests, 8 assertions, 2 failures, 1 errors, 1 skips, 4 requeues in X.XXs (aggregated)
-
-        FAIL ATest#test_bar
-        Expected false to be truthy.
-            test/dummy_test.rb:10:in `test_bar'
-
-        FAIL ATest#test_flaky_fails_retry
-        Expected false to be truthy.
-            test/dummy_test.rb:23:in `test_flaky_fails_retry'
-
-        ERROR BTest#test_bar
-      END
-      assert_includes output, expected_output
     end
 
     def test_utf8_tests_and_marshal


### PR DESCRIPTION
We sometimes have builds which abort early and it's not clear why. With this PR we will print out the build stats and flaky tests to debug this further.