### PR TITLE
Declare Redis >= 5.0 dependency

### DIFF
--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -29,11 +29,12 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
+  spec.add_runtime_dependency 'redis', '>= 5'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')
   spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'redis'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'minitest-reporters', '~> 1.1'
 


### PR DESCRIPTION
Since b403d0c0bfe5d69b9bebad423a4364379496f46e, Redis >= 5 has been a dependency for ci-queue. This commit declares this dependency on the gemspec file.

Relates to #156 .

---

We ran into this issue while troubleshooting a failed dependabot bump on ci-queue. The transitive dependency on `redis` resolved to version 4.8.1 in our app, which satisfied all gems except ci-queue.