### PR TITLE
Use Ruby 3.3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
-          - '3.3.0-rc1'
+          - '3.3.0'
           - 'truffleruby'
     steps:
       - uses: actions/checkout@v2

--- a/ruby/dev.yml
+++ b/ruby/dev.yml
@@ -3,7 +3,7 @@
 name: ci-queue
 
 up:
-- ruby: 3.2.0
+- ruby: 3.3.0
 - bundler
 - redis
 


### PR DESCRIPTION
Use Ruby 3.3.0 in CI and development.