### PR TITLE
Safeguard Time.now

### DIFF
--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -24,6 +24,15 @@ module CI
       RESERVED_LOST_TEST = :RESERVED_LOST_TEST
     end
 
+    GET_NOW = ::Time.method(:now)
+    private_constant :GET_NOW
+    def time_now
+      # Mocks like freeze_time should be cleaned when ci-queue runs, however,
+      # we experienced cases when tests were enqueued with wrong timestamps, so we
+      # safeguard Time.now here.
+      GET_NOW.call
+    end
+
     def requeueable?(test_result)
       requeueable.nil? || requeueable.call(test_result)
     end

--- a/ruby/lib/ci/queue/circuit_breaker.rb
+++ b/ruby/lib/ci/queue/circuit_breaker.rb
@@ -46,7 +46,7 @@ module CI
         private
 
         def current_timestamp
-          Time.now.to_i
+          CI::Queue.time_now.to_i
         end
       end
 

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -32,7 +32,7 @@ module CI
 
         def expired?
           if (created_at = redis.get(key('created-at')))
-            (created_at.to_f + config.redis_ttl + TEN_MINUTES) < Time.now.to_f
+            (created_at.to_f + config.redis_ttl + TEN_MINUTES) < CI::Queue.time_now.to_f
           else
             # if there is no created at set anymore we assume queue is expired
             true

--- a/ruby/lib/ci/queue/redis/supervisor.rb
+++ b/ruby/lib/ci/queue/redis/supervisor.rb
@@ -46,7 +46,7 @@ module CI
 
         def active_workers?
           # if there are running jobs we assume there are still agents active
-          redis.zrangebyscore(key('running'), Time.now.to_f - config.timeout, "+inf", limit: [0,1]).count > 0
+          redis.zrangebyscore(key('running'), CI::Queue.time_now.to_f - config.timeout, "+inf", limit: [0,1]).count > 0
         end
       end
     end

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -175,7 +175,7 @@ module CI
               key('worker', worker_id, 'queue'),
               key('owners'),
             ],
-            argv: [Time.now.to_f],
+            argv: [CI::Queue.time_now.to_f],
           )
         end
 
@@ -188,7 +188,7 @@ module CI
               key('worker', worker_id, 'queue'),
               key('owners'),
             ],
-            argv: [Time.now.to_f, timeout],
+            argv: [CI::Queue.time_now.to_f, timeout],
           )
 
           if lost_test

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -53,7 +53,7 @@ module CI
       end
 
       def expired?
-        (@created_at.to_f TEN_MINUTES) < Time.now.to_f
+        (@created_at.to_f TEN_MINUTES) < CI::Queue.time_now.to_f
       end
 
       def populated?

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -187,7 +187,7 @@ module Minitest
       private
 
       def current_timestamp
-        Time.now.to_i
+        CI::Queue.time_now.to_i
       end
     end
 

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -63,7 +63,7 @@ module Minitest
           end
         end
 
-        queue.rescue_connection_errors { queue.created_at = Time.now.to_f }
+        queue.rescue_connection_errors { queue.created_at = CI::Queue.time_now.to_f }
 
         set_load_path
         Minitest.queue = queue


### PR DESCRIPTION
Safeguard `Time.now`

We had a build which was hanging for a long time. After inspecting the Redis queue, we found that there was one test hanging in the running queue as the expire timestamp was 3 months in the future.

Mocks should be cleaned up when ci-queue runs, however, there might be a case when they leak. This PR makes ci-queue resilient to this.

```
zscore build:unit:018d0bc9-5038-437e-a94e-8976738a051d:running $TEST_ID 
1712077200
```

![image](https://github.com/Shopify/ci-queue/assets/3799140/9f6b03df-0ee3-406a-844f-778243380238)
