### PR TITLE
Add heartbeat

### DIFF
--- a/redis/heartbeat.lua
+++ b/redis/heartbeat.lua
@@ -1,0 +1,17 @@
+local zset_key = KEYS[1]
+local processed_key = KEYS[2]
+local owners_key = KEYS[3]
+local worker_queue_key = KEYS[4]
+
+local current_time = ARGV[1]
+local test = ARGV[2]
+
+-- already processed, we do not need to bump the timestamp
+if redis.call('sismember', processed_key, test) == 1 then
+  return false
+end
+
+-- we're still the owner of the test, we can bump the timestamp
+if redis.call('hget', owners_key, test) == worker_queue_key then
+  return redis.call('zadd', zset_key, current_time, test)
+end

--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -2,6 +2,7 @@
 
 require 'uri'
 require 'cgi'
+require 'json'
 
 require 'ci/queue/version'
 require 'ci/queue/output_helpers'

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -5,7 +5,7 @@ module CI
       attr_accessor :timeout, :worker_id, :max_requeues, :grind_count, :failure_file, :export_flaky_tests_file
       attr_accessor :requeue_tolerance, :namespace, :failing_test, :statsd_endpoint
       attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
-      attr_accessor :max_test_failed, :redis_ttl, :warnings_file, :debug_log
+      attr_accessor :max_test_failed, :redis_ttl, :warnings_file, :debug_log, :max_missed_heartbeat_seconds
       attr_reader :circuit_breakers
       attr_writer :seed, :build_id
       attr_writer :queue_init_timeout, :report_timeout, :inactive_workers_timeout
@@ -37,7 +37,7 @@ module CI
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
         max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil,
         queue_init_timeout: nil, redis_ttl: 8 * 60 * 60, report_timeout: nil, inactive_workers_timeout: nil,
-        export_flaky_tests_file: nil, warnings_file: nil, debug_log: nil)
+        export_flaky_tests_file: nil, warnings_file: nil, debug_log: nil, max_missed_heartbeat_seconds: nil)
         @build_id = build_id
         @circuit_breakers = [CircuitBreaker::Disabled]
         @failure_file = failure_file
@@ -63,6 +63,7 @@ module CI
         @export_flaky_tests_file = export_flaky_tests_file
         @warnings_file = warnings_file
         @debug_log = debug_log
+        @max_missed_heartbeat_seconds = max_missed_heartbeat_seconds
       end
 
       def queue_init_timeout

--- a/ruby/lib/ci/queue/redis/monitor.rb
+++ b/ruby/lib/ci/queue/redis/monitor.rb
@@ -1,0 +1,153 @@
+#!/usr/bin/env -S ruby --disable-gems
+# typed: false
+# frozen_string_literal: true
+
+require 'logger'
+require 'redis'
+require 'json'
+
+module CI
+  module Queue
+    module Redis
+      class Monitor
+        DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../../redis', __FILE__)
+        RELEASE_SCRIPTS_ROOT = ::File.expand_path('../../redis', __FILE__)
+
+        def initialize(pipe, logger, redis_url, zset_key, processed_key, owners_key, worker_queue_key)
+          @zset_key = zset_key
+          @processed_key = processed_key
+          @owners_key = owners_key
+          @worker_queue_key = worker_queue_key
+          @logger = logger
+          @redis = ::Redis.new(url: redis_url, reconnect_attempts: [0, 0, 0.1, 0.5, 1, 3, 5])
+          @shutdown = false
+          @pipe = pipe
+          @self_pipe_reader, @self_pipe_writer = IO.pipe
+          @self_pipe_writer.sync = true
+          @queue = []
+          @deadlines = {}
+          %i[TERM INT USR1].each do |sig|
+            Signal.trap(sig) { soft_signal(sig) }
+          end
+        end
+
+        def soft_signal(sig)
+          @queue << sig
+          @self_pipe_writer << '.'
+        end
+
+        def process_tick!(id:)
+          eval_script(
+            :heartbeat,
+            keys: [@zset_key, @processed_key, @owners_key, @worker_queue_key],
+            argv: [Time.now.to_f, id]
+          )
+        rescue => error
+          @logger.info(error)
+        end
+
+        def eval_script(script, *args)
+          @redis.evalsha(load_script(script), *args)
+        end
+
+        def load_script(script)
+          @scripts_cache ||= {}
+          @scripts_cache[script] ||= @redis.script(:load, read_script(script))
+        end
+
+        def read_script(name)
+          ::File.read(::File.join(DEV_SCRIPTS_ROOT, "#{name}.lua"))
+        rescue SystemCallError
+          ::File.read(::File.join(RELEASE_SCRIPTS_ROOT, "#{name}.lua"))
+        end
+
+        HEADER = 'L'
+        HEADER_SIZE = [0].pack(HEADER).bytesize
+        def read_message(io)
+          case header = io.read_nonblock(HEADER_SIZE, exception: false)
+          when :wait_readable
+            nil
+          when nil
+            @logger.debug('Broken pipe, exiting')
+            @shutdown = 0
+            false
+          else
+            JSON.parse(io.read(header.unpack1(HEADER)))
+          end
+        end
+
+        def process_messages(io)
+          while (message = read_message(io))
+            type, kwargs = message
+            kwargs.transform_keys!(&:to_sym)
+            public_send("process_#{type}", **kwargs)
+          end
+        end
+
+        def wait_for_events(ios)
+          return if @shutdown
+
+          return unless (ready = IO.select(ios, nil, nil, 10))
+
+          ready[0].each do |io|
+            case io
+            when @self_pipe_reader
+              io.read_nonblock(512, exception: false) # Just flush the pipe, the information is in the @queue
+            when @pipe
+              process_messages(@pipe)
+            else
+              @logger.debug("Unknown reader: #{io.inspect}")
+              raise "Unknown reader: #{io.inspect}"
+            end
+          end
+        end
+
+        def monitor
+          @logger.debug("Starting monitor")
+          ios = [@self_pipe_reader, @pipe]
+
+          until @shutdown
+            while (sig = @queue.shift)
+              case sig
+              when :INT, :TERM
+                @logger.debug("Received #{sig}, exiting")
+                @shutdown = 0
+                break
+              else
+                raise "Unknown signal: #{sig.inspect}"
+              end
+            end
+
+            wait_for_events(ios)
+          end
+
+          @logger.debug('Done')
+          @shutdown
+        end
+      end
+    end
+  end
+end
+
+logger = Logger.new($stderr)
+if ARGV.include?('-v')
+  logger.level = Logger::DEBUG
+else
+  logger.level = Logger::INFO
+  logger.formatter = ->(_severity, _timestamp, _progname, msg) { "[CI Queue Monitor] #{msg}\n" }
+end
+
+redis_url = ARGV[0]
+zset_key = ARGV[1]
+processed_key = ARGV[2]
+owners_key = ARGV[3]
+worker_queue_key = ARGV[4]
+
+logger.debug("Starting monitor: #{redis_url} #{zset_key} #{processed_key}")
+manager = CI::Queue::Redis::Monitor.new($stdin, logger, redis_url, zset_key, processed_key, owners_key, worker_queue_key)
+
+# Notify the parent we're ready
+$stdout.puts(".")
+$stdout.close
+
+exit(manager.monitor)

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -144,10 +144,6 @@ module CI
           config.worker_id
         end
 
-        def timeout
-          config.timeout
-        end
-
         def raise_on_mismatching_test(test)
           if @reserved_test == test
             @reserved_test = nil
@@ -180,6 +176,8 @@ module CI
         end
 
         def try_to_reserve_lost_test
+          timeout = config.max_missed_heartbeat_seconds ? config.max_missed_heartbeat_seconds : config.timeout
+
           lost_test = eval_script(
             :reserve_lost,
             keys: [
@@ -192,7 +190,7 @@ module CI
           )
 
           if lost_test
-            build.record_warning(Warnings::RESERVED_LOST_TEST, test: lost_test, timeout: timeout)
+            build.record_warning(Warnings::RESERVED_LOST_TEST, test: lost_test, timeout: config.timeout)
           end
 
           lost_test

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -48,6 +48,16 @@ module CI
         self
       end
 
+      def with_heartbeat(id)
+        yield
+      end
+
+      def ensure_heartbeat_thread_alive!; end
+
+      def boot_heartbeat_process!; end
+
+      def stop_heartbeat!; end
+
       def created_at=(timestamp)
         @created_at ||= timestamp
       end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -226,7 +226,10 @@ module Minitest
 
     def run_from_queue(reporter, *)
       queue.poll do |example|
-        result = example.run
+        result = queue.with_heartbeat(example.id) do
+          example.run
+        end
+
         failed = !(result.passed? || result.skipped?)
 
         if example.flaky?
@@ -256,6 +259,7 @@ module Minitest
           reporter.record(result)
         end
       end
+      queue.stop_heartbeat!
     end
   end
 end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -64,6 +64,7 @@ module Minitest
         end
 
         queue.rescue_connection_errors { queue.created_at = CI::Queue.time_now.to_f }
+        queue.boot_heartbeat_process!
 
         set_load_path
         Minitest.queue = queue
@@ -581,6 +582,16 @@ module Minitest
           opts.on("--redis-ttl SECONDS", Integer, help) do |time|
             queue.config.redis_ttl = time
           end
+
+          help = <<~EOS
+            If heartbeat is enabled, a background process will periodically signal it's still processing
+            the current test. If the heartbeat stops for the specified amount of seconds,
+            the test will be requeued to another worker.
+          EOS
+          opts.on("--heartbeat [SECONDS]", Integer, help) do |time|
+            queue_config.max_missed_heartbeat_seconds = time || 30
+          end
+
 
           opts.on("-v", "--verbose", "Verbose. Show progress processing files.") do
             self.verbose = true

--- a/ruby/test/ci/queue/redis_test.rb
+++ b/ruby/test/ci/queue/redis_test.rb
@@ -89,6 +89,17 @@ class CI::Queue::RedisTest < Minitest::Test
     assert_predicate second_worker, :exhausted?
   end
 
+  def test_monitor_boot_and_shutdown
+    @queue.config.max_missed_heartbeat_seconds = 1
+    @queue.boot_heartbeat_process!
+
+    status = @queue.stop_heartbeat!
+
+    assert_predicate status, :success?
+  ensure
+    @queue.config.max_missed_heartbeat_seconds = nil
+  end
+
   def test_timed_out_test_are_picked_up_by_other_workers
     second_queue = worker(2)
     acquired = false

--- a/ruby/test/fixtures/test/lost_test.rb
+++ b/ruby/test/fixtures/test/lost_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class LostTest < Minitest::Test
+  def test_foo
+    sleep 3
+  end
+end


### PR DESCRIPTION
At the moment, the only way to detect if a worker died is when a test has not been processed in the specified timeout. However, for some tests we have to set a rather large timeout so it would take a while to detect a dead worker.

This PR introduces a heartbeat process. When a worker picks up a test we set a started_at timestamp in Redis. Previously, all tests which were started before `Time.now - timeout` were considered lost and could be picked up by another worker. With the introduced heartbeat process we can now consider a test lost when the last heartbeat was `Time.now - max_missed_heartbeats` which is much faster for tests with a large timeout.

This is implemented via 

* a thread which pushes the current test to the heartbeat monitor
* a heartbeat monitor process which runs as a fork and periodically updates the timestamp of the current test

We've implemented this as a sidecar process as some of our tests do not allow e.g. connections to Redis.