### PR TITLE
Disable reconnect attempts in test suite

### DIFF
--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -35,13 +35,19 @@ module CI
               url: redis_url,
               # Booting a CI worker is costly, so in case of a Redis blip,
               # it makes sense to retry for a while before giving up.
-              reconnect_attempts: [0, 0, 0.1, 0.5, 1, 3, 5],
+              reconnect_attempts: reconnect_attempts,
               middlewares: custom_middlewares,
               custom: custom_config,
             )
           else
             @redis = ::Redis.new(url: redis_url)
           end
+        end
+
+        def reconnect_attempts
+          return [] if ENV["CI_QUEUE_DISABLE_RECONNECT_ATTEMPTS"]
+
+          [0, 0, 0.1, 0.5, 1, 3, 5]
         end
 
         def custom_config

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -437,6 +437,7 @@ module Integration
     def test_down_redis
       out, err = capture_subprocess_io do
         system(
+          { "CI_QUEUE_DISABLE_RECONNECT_ATTEMPTS" => "1" },
           @exe, 'run',
           '--queue', 'redis://localhost:1337',
           '--seed', 'foobar',


### PR DESCRIPTION
Since introducing retry attempts for Redis, the `test_redis_down` takes about 60sec.

## After 

<img width="836" alt="image" src="https://github.com/Shopify/ci-queue/assets/3799140/56cbd8eb-df05-49df-bc2c-833b36d7aacc">

## Before

<img width="871" alt="image" src="https://github.com/Shopify/ci-queue/assets/3799140/ba73655d-9970-49dd-b510-6284b70e888c">


