### PR TITLE
Exit early when there are not many tests left and still workers running

### DIFF
--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -118,6 +118,14 @@ module CI
           end.inject(:+)
         end
 
+        def remaining
+          redis.llen(key('queue'))
+        end
+
+        def running
+          redis.zcard(key('running'))
+        end
+
         def to_a
           redis.multi do |transaction|
             transaction.lrange(key('queue'), 0, -1)

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -78,6 +78,14 @@ module CI
         @queue.size
       end
 
+      def remaining
+        @queue.size
+      end
+
+      def running
+        1
+      end
+
       def poll
         while !@shutdown && config.circuit_breakers.none?(&:open?) && !max_test_failed? && test = @queue.shift
           yield index.fetch(test)


### PR DESCRIPTION
If a job gets (automatically) retried and there are still workers running but not many tests left in the queue, we assume by the time the application is booted the queue is empty and it's faster to no-op.