### PR TITLE
Fix retry queue

### DIFF
--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -83,13 +83,14 @@ module CI
       end
 
       def running
-        1
+        @reserved_test ? 1 : 0
       end
 
       def poll
-        while !@shutdown && config.circuit_breakers.none?(&:open?) && !max_test_failed? && test = @queue.shift
-          yield index.fetch(test)
+        while !@shutdown && config.circuit_breakers.none?(&:open?) && !max_test_failed? && @reserved_test = @queue.shift
+          yield index.fetch(@reserved_test)
         end
+        @reserved_test = nil
       end
 
       def exhausted?


### PR DESCRIPTION
Follow up from https://github.com/Shopify/ci-queue/pull/257

Just had a case when the queue was retried, the retry queue would report 1 test is running and 1 is in the queue and just early abort.

![image](https://github.com/Shopify/ci-queue/assets/3799140/91b2f896-bc37-4a0e-9fa5-37f53079dc63)
