### PR TITLE
Freeze SingleExample#id

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -157,7 +157,7 @@ module Minitest
       end
 
       def id
-        @id ||= "#{@runnable}##{@method_name}"
+        @id ||= "#{@runnable}##{@method_name}".freeze
       end
 
       def <=>(other)


### PR DESCRIPTION
Since Ruby 3.0.0 dynamic strings are not frozen anymore by default which caused the `id` to be stored twice in memory.

## Before
```
81.88 MB  ci-queue-0.46.0/lib/ci/queue/redis/worker.rb:29
66.62 MB  ci-queue-0.46.0/lib/minitest/queue.rb:160
12.56 MB  ci-queue-0.46.0/lib/minitest/queue.rb:207
```

## After
```
66.31 MB  ci-queue-2c7fd4682524/ruby/lib/minitest/queue.rb:160
17.12 MB  ci-queue-2c7fd4682524/ruby/lib/ci/queue/redis/worker.rb:29
11.33 MB  ci-queue-2c7fd4682524/ruby/lib/minitest/queue.rb:207
```