### PR TITLE
Only process retry queue on manual retries

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -49,7 +49,8 @@ module Minitest
 
       def run_command
         require_worker_id!
-        if queue.retrying? || retry?
+        # if it's an automatic job retry we should process the main queue
+        if (queue.retrying? || retry?) && manual_retry?
           if queue.expired?
             abort! "The test run is too old and can't be retried"
           end
@@ -663,6 +664,12 @@ module Minitest
         reopen_previous_step
         puts red(message)
         exit! exit_status # exit! is required to avoid minitest at_exit callback
+      end
+
+      def manual_retry?
+        # this env variable only exists on Buildkite so we should default to manual for backward compatibility
+        retry? &&
+          ENV.fetch("BUILDKITE_RETRY_TYPE", "manual") == "manual"
       end
 
       def retry?


### PR DESCRIPTION
We sometimes have the case that a lot of tests fail in a job and e.g. cause it to OOM or timeout. In this case, jobs often get automatically retried and then process the exact same tests again. We should only process the retry queue on a manual retry. Automatic job retries should join the main queue instead. 

