### PR TITLE
Avoid shell interpolation of re-run commands

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -220,7 +220,7 @@ module Minitest
           command += argv
 
           puts
-          puts "cat <<EOF |\n#{failing_order.to_a.map(&:id).join("\n")}\nEOF\n#{command.join(' ')}"
+          puts "cat <<'EOF' |\n#{failing_order.to_a.map(&:id).join("\n")}\nEOF\n#{command.join(' ')}"
           puts
 
           File.write('log/test_order.log', failing_order.to_a.map(&:id).join("\n"))

--- a/ruby/test/integration/minitest_bisect_test.rb
+++ b/ruby/test/integration/minitest_bisect_test.rb
@@ -89,7 +89,7 @@ module Integration
           LeakyTest#test_sensible_to_leak                                 FAIL
         +++ The following command should reproduce the leak on your machine:
 
-        cat <<EOF |
+        cat <<'EOF' |
         LeakyTest#test_introduce_leak
         LeakyTest#test_sensible_to_leak
         EOF


### PR DESCRIPTION
Recently had a leaky test which looked like;

``` ruby
test "It returns `foo`"
```

Which gave a message from ci-queue;

```
cat <<EOF |
MyTest#it_returns_`foo`
MyTest#other_test
EOF
bundle exec minitest-queue --queue - run -Itest test/my_test.rb
```

When this message is copy-pasted into the terminal it interpolates `foo`, tries to run the command and substitute the output. It gives an error message 

```
zsh: command not found: foo
```

and results in an invalid invocation because the test name is turned into

```
MyTest#it_returns_
```


Adding quotes to the heredoc avoids interpolation and makes the heredoc a literal instead https://www.gnu.org/software/bash/manual/bash.html#Here-Documents