### PR TITLE
Fix bisect command errors when there is nothing to bisect

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -207,6 +207,12 @@ module Minitest
           puts
         end
 
+        if run_index == 0
+          step(yellow("The failing test was the first test in the test order so there is nothing to bisect."))
+          File.write('log/test_order.log', "")
+          exit! 1
+        end
+
         failing_order = queue.candidates
         step("Final validation")
         status = if run_tests_in_fork(failing_order)

--- a/ruby/test/integration/minitest_bisect_test.rb
+++ b/ruby/test/integration/minitest_bisect_test.rb
@@ -100,7 +100,7 @@ module Integration
       assert_equal expected_output, normalize(out)
     end
 
-    def test_unconclusive
+    def test_inconclusive
       out, err = capture_subprocess_io do
         run_bisect('log/unconclusive_test_order.log', 'LeakyTest#test_sensible_to_leak')
       end
@@ -172,6 +172,21 @@ module Integration
           LeakyTest#test_useless_43                                       PASS
           LeakyTest#test_sensible_to_leak                                 PASS
         --- The bisection was inconclusive, there might not be any leaky test here.
+      EOS
+
+      assert_equal expected_output, normalize(out)
+    end
+
+    def test_failing_test_is_the_first_entry_in_the_test_order
+      out, err = capture_subprocess_io do
+        run_bisect('log/unconclusive_test_order.log', 'LeakyTest#test_useless_0')
+      end
+
+      assert_empty err
+      expected_output = strip_heredoc <<-EOS
+        --- Testing the failing test in isolation
+          LeakyTest#test_useless_0                                        PASS
+        --- The failing test was the first test in the test order so there is nothing to bisect.
       EOS
 
       assert_equal expected_output, normalize(out)


### PR DESCRIPTION
Related to https://github.com/Shopify/test-infra/issues/2502

I have been seeing some errors when the failing test given to the bisect command is the first test in the test order file - 
* https://buildkite.com/shopify/shopify-leakbot/builds/18551#018e8526-d140-4e42-abcb-d3ceaa8d46c0/280-295
* https://buildkite.com/shopify/shopify-leakbot/builds/18716#018e86dd-9d70-46aa-b5b6-37cf0805b960/280-296

This was an edge case that we probably did not consider before. We should fail the job gracefully when there is nothing to bisect.