### PR TITLE
Handle key errors gracefully in a static queue

### DIFF
--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -71,7 +71,12 @@ module CI
       end
 
       def to_a
-        @queue.map { |i| index.fetch(i) }
+        @queue.map do |i|
+          index.fetch(i)
+        rescue KeyError
+          puts "Test not found: #{i}"
+          nil
+        end.compact
       end
 
       def size
@@ -88,7 +93,11 @@ module CI
 
       def poll
         while !@shutdown && config.circuit_breakers.none?(&:open?) && !max_test_failed? && @reserved_test = @queue.shift
-          yield index.fetch(@reserved_test)
+          begin
+            yield index.fetch(@reserved_test)
+          rescue KeyError
+            puts "Test not found: #{@reserved_test}"
+          end
         end
         @reserved_test = nil
       end

--- a/ruby/test/ci/queue/static_test.rb
+++ b/ruby/test/ci/queue/static_test.rb
@@ -12,6 +12,36 @@ class CI::Queue::StaticTest < Minitest::Test
     refute queue.expired?
   end
 
+  def test_poll_skips_missing_test
+    queue = CI::Queue::Static.new((TEST_LIST + [TestCase.new('ATest#i_do_not_exist')]).map(&:id), config)
+    populate(queue)
+
+    expected_output = <<~OUTPUT
+      Test not found: ATest#i_do_not_exist
+    OUTPUT
+
+    out, _ = capture_io do
+      assert_equal shuffled_test_list, poll(queue)
+    end
+
+    assert_equal expected_output, out
+  end
+
+  def test_to_a_skips_missing_test
+    queue = CI::Queue::Static.new((TEST_LIST + [TestCase.new('ATest#i_do_not_exist')]).map(&:id), config)
+    populate(queue)
+
+    expected_output = <<~OUTPUT
+      Test not found: ATest#i_do_not_exist
+    OUTPUT
+
+    out, _ = capture_io do
+      assert_equal shuffled_test_list, queue.to_a
+    end
+
+    assert_equal expected_output, out
+  end
+
   private
 
   def build_queue


### PR DESCRIPTION
The static queue executes tests during bisect and it leads to an incorrect outcome plus unexpected errors when we specify a non-existing test ID in the test order provided to the bisect command. We want to start bisecting test orders in `main` to reduce false positive outcomes. So several test IDs in a given flaky test order that was captured in an older commit could now be missing due to change in test file path / renamed test / deleted test. If we don't handle missing keys gracefully, bisect incorrect thinks that the static queue came across a test failure, which leads to incorrect outcomes. 