### PR TITLE
Initialize bisect queue after loading tests

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -182,10 +182,10 @@ module Minitest
       def bisect_command
         invalid_usage! "Missing the FAILING_TEST argument." unless queue_config.failing_test
 
-        @queue = CI::Queue::Bisect.new(queue_url, queue_config)
-        Minitest.queue = queue
         set_load_path
         load_tests
+        @queue = CI::Queue::Bisect.new(queue_url, queue_config)
+        Minitest.queue = queue
         populate_queue
 
         step("Testing the failing test in isolation")


### PR DESCRIPTION
Follow-up on https://github.com/Shopify/ci-queue/pull/272. We're going clean the test order file given to bisect from the client side instead. Specifically from the file which loads all the tests. We're going to introspect the currently existing tests based on what's available in `Minitest::Test.runnables`. To make sure that ci-queue reads the cleaned test order file, we need to initialize the bisect queue after it runs `load_tests`. 