### PR TITLE
Return true if queue is initialized

### DIFF
--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -139,6 +139,8 @@ module CI
 
         def wait_for_master(timeout: 30)
           return true if master?
+          return true if queue_initialized?
+
           (timeout * 10 + 1).to_i.times do
             if queue_initialized?
               return true
@@ -146,6 +148,7 @@ module CI
               sleep 0.1
             end
           end
+
           raise LostMaster, "The master worker is still `#{master_status}` after #{timeout} seconds waiting."
         end
 


### PR DESCRIPTION
When checking several groups, we dynamically reduce the timeout depending on the used timeout of the previous group. However, if the timeout is <0 (because the previous groups used all of the timeout available) we will crash with a `LostMaster` error. If the master is ready though, we should let ci-queue gracefully handle this case. 