### PR TITLE
Fix condition for empty bisect

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -208,7 +208,7 @@ module Minitest
           puts
         end
 
-        if run_index == 0
+        if queue.suspects_left == 0
           step(yellow("The failing test was the first test in the test order so there is nothing to bisect."))
           File.write('log/test_order.log', "")
           exit! 1


### PR DESCRIPTION
We were incorrectly reaching this code block when a test order file has two tests. This PR fixes the condition for detecting when there is nothing to bisect.