### PR TITLE
Gracefully handle non-existing failing test given to bisect

### DIFF
--- a/ruby/lib/ci/queue/bisect.rb
+++ b/ruby/lib/ci/queue/bisect.rb
@@ -27,6 +27,10 @@ module CI
         Static.new([config.failing_test], config).populate(@all_tests)
       end
 
+      def failing_test_present?
+        @all_tests.find { |t| t.id == config.failing_test }
+      end
+
       def candidates
         Static.new(first_half + [config.failing_test], config).populate(@all_tests)
       end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -189,6 +189,13 @@ module Minitest
         populate_queue
 
         step("Testing the failing test in isolation")
+        unless queue.failing_test_present?
+          puts reopen_previous_step
+          puts red("The failing test does not exist.")
+          File.write('log/test_order.log', "")
+          exit! 1
+        end
+
         unless run_tests_in_fork(queue.failing_test)
           puts reopen_previous_step
           puts red("The test fail when ran alone, no need to bisect.")

--- a/ruby/test/integration/minitest_bisect_test.rb
+++ b/ruby/test/integration/minitest_bisect_test.rb
@@ -286,6 +286,22 @@ module Integration
       assert_equal expected_output, normalize(out)
     end
 
+    def test_failing_test_is_not_present
+      out, err = capture_subprocess_io do
+        run_bisect('log/leaky_test_order.log', 'LeakyTestDoesNotExist#test_sensible_to_leak')
+      end
+
+      assert_empty err
+      expected_output = strip_heredoc <<-EOS
+        --- Testing the failing test in isolation
+        ^^^ +++
+
+        The failing test does not exist.
+      EOS
+
+      assert_equal expected_output, normalize(out)
+    end
+
     private
 
     def normalize(output)


### PR DESCRIPTION
Since we started periodically reproducing state leaks, I saw some cases where the failing test does not exist anymore. In such cases, the bisect command thinks that the failing test independently fails because the `run_tests_in_fork(queue.failing_test)` returns false - 
```
--- Testing the failing test in isolation
/tmp/bundle/ruby/3.4.0+0/gems/ci-queue-0.52.0/lib/ci/queue/static.rb:91:in 'Hash#fetch': key not found: "Sales::ApiOrderToOrderServiceTest#test_an_order_... (KeyError)
--
  | Did you mean?  "Sales::OrderEditing::LineItemBuilderTest#test_some_other_test"
  | from /tmp/bundle/ruby/3.4.0+0/gems/ci-queue-0.52.0/lib/ci/queue/static.rb:91:in 'CI::Queue::Static#poll'
  | from /tmp/bundle/ruby/3.4.0+0/gems/ci-queue-0.52.0/lib/minitest/queue.rb:229:in 'Minitest::Queue#run_from_queue'
  | from /tmp/bundle/ruby/3.4.0+0/gems/ci-queue-0.52.0/lib/minitest/queue.rb:214:in 'Minitest::Queue#__run

...
The test fail when ran alone, no need to bisect.
```

This PR gracefully handles the case when the failing test does not exist.