### PR TITLE
Add logs around leader election

### DIFF
--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -185,6 +185,12 @@ module CI
 
         attr_reader :redis, :redis_url
 
+        def measure
+          starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          yield
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - starting
+        end
+
         def key(*args)
           ['build', build_id, *args].join(':')
         end

--- a/ruby/lib/ci/queue/redis/supervisor.rb
+++ b/ruby/lib/ci/queue/redis/supervisor.rb
@@ -47,12 +47,6 @@ module CI
 
         private
 
-        def measure
-          starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          yield
-          Process.clock_gettime(Process::CLOCK_MONOTONIC) - starting
-        end
-
         def active_workers?
           # if there are running jobs we assume there are still agents active
           redis.zrangebyscore(key('running'), CI::Queue.time_now.to_f - config.timeout, "+inf", limit: [0,1]).count > 0

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -223,7 +223,7 @@ module Minitest
 
         failing_order = queue.candidates
         step("Final validation")
-        status = if run_tests_in_fork(failing_order)
+        if run_tests_in_fork(failing_order)
           step(yellow("The bisection was inconclusive, there might not be any leaky test here."))
           File.write('log/test_order.log', "")
           exit! 1
@@ -314,7 +314,8 @@ module Minitest
       private
 
       attr_reader :queue_config, :options, :command, :argv
-      attr_accessor :queue, :queue_url, :grind_list, :grind_count, :load_paths, :verbose
+      attr_writer :queue_url
+      attr_accessor :queue, :grind_list, :grind_count, :load_paths, :verbose
 
       def require_worker_id!
         if queue.distributed?

--- a/ruby/test/ci/queue/redis_supervisor_test.rb
+++ b/ruby/test/ci/queue/redis_supervisor_test.rb
@@ -48,7 +48,7 @@ class CI::Queue::Redis::SupervisorTest < Minitest::Test
     thread.wakeup
     worker(1)
     thread.join
-    assert_includes io, "Aborting, it seems all workers died.\n"
+    assert_includes io.join, "Aborting, it seems all workers died.\n"
   end
 
   def test_num_workers

--- a/ruby/test/ci/queue/redis_test.rb
+++ b/ruby/test/ci/queue/redis_test.rb
@@ -281,7 +281,8 @@ class CI::Queue::RedisTest < Minitest::Test
   end
 
   def populate(worker, tests: TEST_LIST.dup)
-    worker.populate(tests, random: Random.new(0))
+    capture_io { worker.populate(tests, random: Random.new(0)) }
+    worker
   end
 
   def worker(id, **args)

--- a/ruby/test/ci/queue/redis_test.rb
+++ b/ruby/test/ci/queue/redis_test.rb
@@ -281,8 +281,7 @@ class CI::Queue::RedisTest < Minitest::Test
   end
 
   def populate(worker, tests: TEST_LIST.dup)
-    capture_io { worker.populate(tests, random: Random.new(0)) }
-    worker
+    worker.populate(tests, random: Random.new(0))
   end
 
   def worker(id, **args)

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -216,7 +216,6 @@ module Integration
       assert_equal 'Ran 47 tests, 47 assertions, 3 failures, 0 errors, 0 skips, 44 requeues in X.XXs', output
 
       # Run the reporter
-      exit_code = nil
       out, err = capture_subprocess_io do
         system(
           @exe, 'report',
@@ -862,12 +861,6 @@ module Integration
           )
         end
 
-        warning = <<~END
-          [WARNING] Atest#test_bar was picked up by another worker because it didn't complete in the allocated 2 seconds.
-          You may want to either optimize this test or bump ci-queue timeout.
-          It's also possible that the worker that was processing it was terminated without being able to report back.
-        END
-
         warnings_file.rewind
         content = JSON.parse(warnings_file.read)
         assert_equal 1, content.size
@@ -953,7 +946,7 @@ module Integration
 
       assert_equal 42, $?.exitstatus
 
-      out, err = capture_subprocess_io do
+      out, _ = capture_subprocess_io do
         system(
           @exe, 'report',
           '--queue', @redis_url,

--- a/ruby/test/integration/rspec_redis_test.rb
+++ b/ruby/test/integration/rspec_redis_test.rb
@@ -34,6 +34,9 @@ module Integration
 
       assert_empty err
       expected_output = strip_heredoc <<-EOS
+        Worker electected as leader, pushing 3 tests to the queue.
+
+        Finished pushing 3 tests to the queue in X.XXs.
 
         Randomized with seed 123
         ..*.
@@ -88,6 +91,9 @@ module Integration
 
       assert_empty err
       expected_output = strip_heredoc <<-EOS
+        Worker electected as leader, pushing 3 tests to the queue.
+
+        Finished pushing 3 tests to the queue in X.XXs.
 
         Randomized with seed 123
         ..*.
@@ -267,6 +273,9 @@ module Integration
 
       assert_empty err
       expected_output = strip_heredoc <<-EOS
+        Worker electected as leader, pushing 2 tests to the queue.
+
+        Finished pushing 2 tests to the queue in X.XXs.
 
         Randomized with seed 123
 
@@ -308,6 +317,9 @@ module Integration
 
       assert_empty err
       expected_output = strip_heredoc <<-EOS
+        Worker electected as leader, pushing 3 tests to the queue.
+
+        Finished pushing 3 tests to the queue in X.XXs.
 
         Randomized with seed 123
         ..F
@@ -379,11 +391,12 @@ module Integration
       end
 
       assert_empty err
+
       expected_output = strip_heredoc <<-EOS
 
 
-        Finished in X.XXXXX seconds (files took X.XXXXX seconds to load)
-        0 examples, 0 failures
+      Finished in X.XXXXX seconds (files took X.XXXXX seconds to load)
+      0 examples, 0 failures
 
       EOS
       assert_equal expected_output, normalize(out)
@@ -405,6 +418,9 @@ module Integration
 
       assert_empty err
       expected_output = strip_heredoc <<-EOS
+        Worker electected as leader, pushing 1 tests to the queue.
+
+        Finished pushing 1 tests to the queue in X.XXs.
 
         Randomized with seed 123
         F

--- a/ruby/test/support/shared_queue_assertions.rb
+++ b/ruby/test/support/shared_queue_assertions.rb
@@ -6,7 +6,7 @@ module SharedQueueAssertions
   include QueueHelper
 
   def setup
-    @queue = populate(build_queue)
+    capture_io { @queue = populate(build_queue) }
   end
 
   def test_progess


### PR DESCRIPTION
We sometimes have builds timing out pushing tests to the queue but it's hard to debug because I don't know which of the workers is the leader. Adding some log output about leader election and pushing tests to the queue.