### PR TITLE
Fix static queue

### DIFF
--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -58,6 +58,8 @@ module CI
 
       def stop_heartbeat!; end
 
+      def report_worker_error(error); end
+
       def created_at=(timestamp)
         @created_at ||= timestamp
       end


### PR DESCRIPTION
Follow up from https://github.com/Shopify/ci-queue/pull/284, crashes locally.

```
undefined method `report_worker_error' for an instance of CI::Queue::File (NoMethodError)

      queue.report_worker_error(error)
           ^^^^^^^^^^^^^^^^^^^^
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/ci-queue-0.56.0/lib/minitest/queue.rb:228:in `run_from_queue'
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/ci-queue-0.56.0/lib/minitest/queue.rb:214:in `__run'
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/minitest-5.24.1/lib/minitest.rb:288:in `run'
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/minitest-5.24.1/lib/minitest.rb:86:in `block in autorun'
/home/spin/.bundle/shopify/ruby-3.3.3/gems/ci-queue-0.56.0/lib/ci/queue/static.rb:91:in `fetch': key not found: "Checkouts::One::Web::Policies::Artifact::DefaultMerchandisePo... (KeyError)
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/ci-queue-0.56.0/lib/ci/queue/static.rb:91:in `poll'
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/ci-queue-0.56.0/lib/minitest/queue.rb:229:in `run_from_queue'
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/ci-queue-0.56.0/lib/minitest/queue.rb:214:in `__run'
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/minitest-5.24.1/lib/minitest.rb:288:in `run'
	from /home/spin/.bundle/shopify/ruby-3.3.3/gems/minitest-5.24.1/lib/minitest.rb:86:in `block in autorun'
```