### PR TITLE
Log before and after commands are issued

### DIFF
--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -13,16 +13,18 @@ module CI
 
         module RedisInstrumentation
           def call(command, redis_config)
-            result = super
             logger = redis_config.custom[:debug_log]
-            logger.info("#{command}: #{result}")
+            logger.info("Running '#{command}'")
+            result = super
+            logger.info("Finished '#{command}': #{result}")
             result
           end
 
           def call_pipelined(commands, redis_config)
-            result = super
             logger = redis_config.custom[:debug_log]
-            logger.info("#{commands}: #{result}")
+            logger.info("Running '#{commands}'")
+            result = super
+            logger.info("Finished '#{commands}': #{result}")
             result
           end
         end

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -138,7 +138,7 @@ module Integration
           )
         end
 
-      assert_includes File.read(log_file.path), 'INFO -- : ["exists", "build:1:worker:1:queue"]: 0'
+      assert_includes File.read(log_file.path), 'INFO -- : Finished \'["exists", "build:1:worker:1:queue"]\': 0'
       assert_empty err
       result = normalize(out.lines.last.strip)
       assert_equal '--- Ran 11 tests, 8 assertions, 2 failures, 1 errors, 1 skips, 4 requeues in X.XXs', result


### PR DESCRIPTION
We should log before and after each Redis call to make debugging easier.