### PR TITLE
Declare missing logger dependency

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ci-queue (0.58.0)
+      logger
 
 GEM
   remote: https://rubygems.org/
@@ -30,6 +31,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     minitest (5.22.3)
     minitest-reporters (1.6.1)
       ansi

--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
+  spec.add_runtime_dependency 'logger'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')


### PR DESCRIPTION
Otherwise it output a warning on Ruby 3.4