### PR TITLE
Allow using hosted Redis instances by default

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -3,7 +3,7 @@ module CI
   module Queue
     class Configuration
       attr_accessor :timeout, :worker_id, :max_requeues, :grind_count, :failure_file, :export_flaky_tests_file
-      attr_accessor :requeue_tolerance, :namespace, :failing_test, :statsd_endpoint
+      attr_accessor :requeue_tolerance, :namespace, :failing_test, :statsd_endpoint, :strict_ssl
       attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
       attr_accessor :max_test_failed, :redis_ttl, :warnings_file, :debug_log, :max_missed_heartbeat_seconds
       attr_reader :circuit_breakers
@@ -37,7 +37,8 @@ module CI
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
         max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil,
         queue_init_timeout: nil, redis_ttl: 8 * 60 * 60, report_timeout: nil, inactive_workers_timeout: nil,
-        export_flaky_tests_file: nil, warnings_file: nil, debug_log: nil, max_missed_heartbeat_seconds: nil)
+        export_flaky_tests_file: nil, warnings_file: nil, debug_log: nil, max_missed_heartbeat_seconds: nil,
+        strict_ssl: false)
         @build_id = build_id
         @circuit_breakers = [CircuitBreaker::Disabled]
         @failure_file = failure_file
@@ -51,6 +52,7 @@ module CI
         @requeue_tolerance = requeue_tolerance
         @seed = seed
         @statsd_endpoint = statsd_endpoint
+        @strict_ssl = strict_ssl
         @timeout = timeout
         @queue_init_timeout = queue_init_timeout
         @track_test_duration = track_test_duration

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -33,14 +33,15 @@ module CI
           @redis_url = redis_url
           @config = config
           if ::Redis::VERSION > "5.0.0"
-            @redis = ::Redis.new(
+            connection_options = {
               url: redis_url,
               # Booting a CI worker is costly, so in case of a Redis blip,
               # it makes sense to retry for a while before giving up.
               reconnect_attempts: reconnect_attempts,
               middlewares: custom_middlewares,
               custom: custom_config,
-            )
+            }
+            @redis = ::Redis.new(**connection_options)
           else
             @redis = ::Redis.new(url: redis_url)
           end

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -41,6 +41,11 @@ module CI
               middlewares: custom_middlewares,
               custom: custom_config,
             }
+
+            if !config.strict_ssl
+              connection_options[:ssl_params] = { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+            end
+
             @redis = ::Redis.new(**connection_options)
           else
             @redis = ::Redis.new(url: redis_url)

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -444,6 +444,15 @@ module Minitest
           end
 
           help = <<~EOS
+            Force strict SSL checks on the Redis connection.
+            The default connection behavior is to set SSL verification to `OpenSSL::SSL::VERIFY_NONE` because hosted Redis services may use self-signed certificates.
+            When this flag is activated, the full TLS check will be performed.
+          EOS
+          parser.on('--strict-ssl', *help) do
+            queue_config.strict_ssl = true
+          end
+
+          help = <<~EOS
             Specify a timeout after which the report command will fail if not all tests have been processed.
             Defaults to the value set for --timeout.
           EOS

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -77,6 +77,15 @@ module RSpec
         end
 
         help = <<~EOS
+          Force strict SSL checks on the Redis connection.
+          The default connection behavior is to set SSL verification to `OpenSSL::SSL::VERIFY_NONE` because hosted Redis services may use self-signed certificates.
+          When this flag is activated, the full TLS check will be performed.
+        EOS
+        parser.on('--strict-ssl', *help) do
+          queue_config.strict_ssl = true
+        end
+
+        help = <<~EOS
           Wait for all workers to complete and summarize the test failures.
         EOS
         parser.on('--report', *help) do |url|


### PR DESCRIPTION
Hosted Redis servers use self signed certificates (because they do not own the domain they're running on such as `compute-1.amazonaws.com`) therefore a full SSL connection verification will fail. The fix for that behavior is to disable verification so a self signed certificate can be used [docs from a hosted Redis/Key-value store provider](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby).

This PR makes the default behavior to allow connecting to self signed Redis servers, and introduces a new flag `--strict-ssl` which will require that the certificate is not self-signed. 

This failing SSL connection behavior was originally reported in https://github.com/Shopify/ci-queue/issues/292, however that issue focues on raising visibility of such failures.