### PR TITLE
Allow using hosted Redis instances by default

### DIFF
--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -39,6 +39,7 @@ module CI
               # it makes sense to retry for a while before giving up.
               reconnect_attempts: reconnect_attempts,
               middlewares: custom_middlewares,
+              ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE },
               custom: custom_config,
             )
           else


### PR DESCRIPTION
Hosted Redis servers use self signed certificates (because they do not own the domain they're running on such as `compute-1.amazonaws.com`) therefore a full SSL connection verification will fail. The fix for that behavior is to disable verification so a self signed certificate can be used [docs from a hosted Redis/Key-value store provider](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby).

This PR makes the default behavior to allow connecting to self signed Redis servers. 

This failing SSL connection behavior was originally reported in https://github.com/Shopify/ci-queue/issues/292, however that issue focuses on raising visibility of such failures.

This is an alternative to #293 that does not introduce a new configuration flag.