### PR TITLE
Stop passing unused block

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -350,7 +350,7 @@ module Minitest
       end
 
       def populate_queue
-        Minitest.queue.populate(Minitest.loaded_tests, random: ordering_seed, &:id)
+        Minitest.queue.populate(Minitest.loaded_tests, random: ordering_seed)
       end
 
       def set_load_path


### PR DESCRIPTION
Found with the new warning in Ruby 3.4.