### PR TITLE
Print worker crash reports in red

### DIFF
--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -37,7 +37,7 @@ module Minitest
         end
 
         build.worker_errors.to_a.sort.each do |worker_id, error|
-          puts yellow("Worker #{worker_id } crashed")
+          puts red("Worker #{worker_id } crashed")
           puts error
           puts ""
         end


### PR DESCRIPTION
This makes the job fail so it should be printed in red.