### PR TITLE
Ignore ci-queue errors

### DIFF
--- a/ruby/lib/ci/queue/redis.rb
+++ b/ruby/lib/ci/queue/redis.rb
@@ -16,6 +16,7 @@ module CI
     module Redis
       Error = Class.new(StandardError)
       LostMaster = Class.new(Error)
+      ReservationError = Class.new(Error)
 
       class << self
 

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -5,8 +5,6 @@ require 'set'
 module CI
   module Queue
     module Redis
-      ReservationError = Class.new(StandardError)
-
       class << self
         attr_accessor :requeue_offset
       end

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -266,6 +266,13 @@ module Minitest
       reopen_previous_step
       puts red("The heartbeat process died. This worker is exiting early.")
       exit!(41)
+    rescue CI::Queue::Redis::Error
+      reopen_previous_step
+      puts red("#{error.class}: #{error.message}")
+      error.backtrace.each do |frame|
+        puts red(frame)
+      end
+      exit!(41)
     rescue => error
       reopen_previous_step
       queue.report_worker_error(error)


### PR DESCRIPTION
We should not fail the test suite on ci-queue errors and just allow to retry instead.