### PR TITLE
Fix retry queue

### DIFF
--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -60,6 +60,10 @@ module CI
 
       def report_worker_error(error); end
 
+      def queue_initialized?
+        true
+      end
+
       def created_at=(timestamp)
         @created_at ||= timestamp
       end


### PR DESCRIPTION
Manual retries will fail since https://github.com/Shopify/ci-queue/pull/296 as the methods doesn't exist on the static queue.