### PR TITLE
Fix rescue

### DIFF
--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -21,6 +21,8 @@ module CI
 
     attr_accessor :shuffler, :requeueable
 
+    Error = Class.new(StandardError)
+
     module Warnings
       RESERVED_LOST_TEST = :RESERVED_LOST_TEST
     end

--- a/ruby/lib/ci/queue/redis.rb
+++ b/ruby/lib/ci/queue/redis.rb
@@ -14,9 +14,8 @@ require 'ci/queue/redis/test_time_record'
 module CI
   module Queue
     module Redis
-      Error = Class.new(StandardError)
-      LostMaster = Class.new(Error)
-      ReservationError = Class.new(Error)
+      LostMaster = Class.new(CI::Queue::Error)
+      ReservationError = Class.new(CI::Queue::Error)
 
       class << self
 

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -266,7 +266,7 @@ module Minitest
       reopen_previous_step
       puts red("The heartbeat process died. This worker is exiting early.")
       exit!(41)
-    rescue CI::Queue::Redis::Error
+    rescue CI::Queue::Error
       reopen_previous_step
       puts red("#{error.class}: #{error.message}")
       error.backtrace.each do |frame|


### PR DESCRIPTION
In case we use a static queue the errors are not loaded properly.

https://github.com/Shopify/ci-queue/blob/d23f35d1332079183ed337c1caffe436965632fd/ruby/lib/ci/queue.rb#L52-L59

Related to https://github.com/Shopify/ci-queue/pull/298