### PR TITLE
feat: add support for --export-skipped-tests-file

### DIFF
--- a/ruby/lib/ci/queue/build_record.rb
+++ b/ruby/lib/ci/queue/build_record.rb
@@ -23,7 +23,7 @@ module CI
         record_stats(stats)
       end
 
-      def record_success(id, stats: nil, skip_flaky_record: false)
+      def record_success(id, stats: nil, skipped: false, requeued: false)
         error_reports.delete(id)
         record_stats(stats)
       end

--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -2,7 +2,7 @@
 module CI
   module Queue
     class Configuration
-      attr_accessor :timeout, :worker_id, :max_requeues, :grind_count, :failure_file, :export_flaky_tests_file
+      attr_accessor :timeout, :worker_id, :max_requeues, :grind_count, :failure_file, :export_flaky_tests_file, :export_skipped_tests_file
       attr_accessor :requeue_tolerance, :namespace, :failing_test, :statsd_endpoint
       attr_accessor :max_test_duration, :max_test_duration_percentile, :track_test_duration
       attr_accessor :max_test_failed, :redis_ttl, :warnings_file, :debug_log, :max_missed_heartbeat_seconds
@@ -37,7 +37,8 @@ module CI
         grind_count: nil, max_duration: nil, failure_file: nil, max_test_duration: nil,
         max_test_duration_percentile: 0.5, track_test_duration: false, max_test_failed: nil,
         queue_init_timeout: nil, redis_ttl: 8 * 60 * 60, report_timeout: nil, inactive_workers_timeout: nil,
-        export_flaky_tests_file: nil, warnings_file: nil, debug_log: nil, max_missed_heartbeat_seconds: nil)
+        export_flaky_tests_file: nil, warnings_file: nil, debug_log: nil, max_missed_heartbeat_seconds: nil,
+        export_skipped_tests_file: nil)
         @build_id = build_id
         @circuit_breakers = [CircuitBreaker::Disabled]
         @failure_file = failure_file
@@ -61,6 +62,7 @@ module CI
         @report_timeout = report_timeout
         @inactive_workers_timeout = inactive_workers_timeout
         @export_flaky_tests_file = export_flaky_tests_file
+        @export_skipped_tests_file = export_skipped_tests_file
         @warnings_file = warnings_file
         @debug_log = debug_log
         @max_missed_heartbeat_seconds = max_missed_heartbeat_seconds

--- a/ruby/lib/minitest/queue/build_status_recorder.rb
+++ b/ruby/lib/minitest/queue/build_status_recorder.rb
@@ -52,7 +52,7 @@ module Minitest
         if (test.failure || test.error?) && !test.skipped?
           build.record_error("#{test.klass}##{test.name}", dump(test), stats: stats)
         else
-          build.record_success("#{test.klass}##{test.name}", stats: stats, skip_flaky_record: test.skipped?)
+          build.record_success("#{test.klass}##{test.name}", stats: stats, skipped: test.skipped?, requeued: test.requeued?)
         end
       end
 

--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -21,6 +21,10 @@ module Minitest
         build.flaky_reports
       end
 
+      def skipped_reports
+        build.skipped_reports
+      end
+
       def requeued_tests
         build.requeued_tests
       end
@@ -88,6 +92,10 @@ module Minitest
 
       def write_flaky_tests_file(file)
         File.write(file, flaky_reports.to_json)
+      end
+
+      def write_skipped_tests_file(file)
+        File.write(file, skipped_reports.to_json)
       end
 
       private

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -261,6 +261,7 @@ module Minitest
             reporter.report
             reporter.write_failure_file(queue_config.failure_file) if queue_config.failure_file
             reporter.write_flaky_tests_file(queue_config.export_flaky_tests_file) if queue_config.export_flaky_tests_file
+            reporter.write_skipped_tests_file(queue_config.export_skipped_tests_file) if queue_config.export_skipped_tests_file
 
             msg = "#{supervisor.size} tests weren't run."
 
@@ -276,6 +277,7 @@ module Minitest
         reporter = BuildStatusReporter.new(build: supervisor.build)
         reporter.write_failure_file(queue_config.failure_file) if queue_config.failure_file
         reporter.write_flaky_tests_file(queue_config.export_flaky_tests_file) if queue_config.export_flaky_tests_file
+        reporter.write_skipped_tests_file(queue_config.export_skipped_tests_file) if queue_config.export_skipped_tests_file
         reporter.report
 
         exit! reporter.success? ? 0 : 1
@@ -549,6 +551,15 @@ module Minitest
           opts.separator ""
           opts.on('--export-flaky-tests-file FILE', help) do |file|
             queue_config.export_flaky_tests_file = file
+          end
+
+          help = <<~EOS
+            Defines a file where skipped tests during the execution are written to in json format.
+            Defaults to disabled.
+          EOS
+          opts.separator ""
+          opts.on('--export-skipped-tests-file FILE', help) do |file|
+            queue_config.export_skipped_tests_file = file
           end
 
           help = <<~EOS

--- a/ruby/test/minitest/queue/build_status_recorder_test.rb
+++ b/ruby/test/minitest/queue/build_status_recorder_test.rb
@@ -37,6 +37,7 @@ module Minitest::Queue
       assert_equal 1, summary.requeues
       assert_equal 5, summary.error_reports.size
       assert_equal 0, summary.flaky_reports.size
+      assert_equal 2, summary.skipped_reports.size
     end
 
     def test_retrying_test


### PR DESCRIPTION
I've observed failing tests being skipped in a codebase even though the test file wasn't employing the clear and self documenting "skip" method to achieve this. At scale this makes it hard to reason about which tests are actually run and which are skipped.

I wish to create a central file `test_todo.yml` containing all tests that are allowed to be skipped like so:

```
skipped:
  - test/unit/a_test.rb
```

Then I can write a CI job that complains if tests not explicitly marked as skipped centrally is skipped.