### PR TITLE
Add optional attributes message and stacktrace to skipped children in JunitXML

### DIFF
--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -87,7 +87,8 @@ module Minitest
       def add_xml_message_for(testcase, test)
         failure = test.failure
         if test.skipped? && !test.flaked?
-          testcase.add_element('skipped', 'type' => failure.error.class.name)
+          skip = testcase.add_element('skipped', 'type' => failure.error.class.name, 'message' => truncate_message(failure.message))
+          skip.add_text(REXML::CData.new(message_for(test)))
         elsif test.error?
           error = testcase.add_element('error', 'type' => failure.error.class.name, 'message' => truncate_message(failure.message))
           error.add_text(REXML::CData.new(message_for(test)))

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -674,10 +674,22 @@ module Integration
         <testsuites>
           <testsuite name="ATest" filepath="test/dummy_test.rb" skipped="5" failures="1" errors="0" tests="6" assertions="5" time="X.XX">
             <testcase name="test_foo" classname="ATest" assertions="0" time="X.XX" timestamp="X.XX" flaky_test="false" run-command=\"bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_foo\" lineno="5">
-              <skipped type="Minitest::Skip"/>
+              <skipped type="Minitest::Skip" message="Skipped, no message given">
+                <![CDATA[
+        Skipped:
+        test_foo(ATest) [test/dummy_test.rb]:
+        Skipped, no message given
+        ]]>
+              </skipped>
             </testcase>
             <testcase name="test_bar" classname="ATest" assertions="1" time="X.XX" timestamp="X.XX" flaky_test="false" run-command=\"bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_bar\" lineno="5">
-              <skipped type="Minitest::Assertion"/>
+              <skipped type="Minitest::Assertion" message="Expected false to be truthy.">
+                <![CDATA[
+        Skipped:
+        test_bar(ATest) [test/dummy_test.rb]:
+        Expected false to be truthy.
+        ]]>
+              </skipped>
             </testcase>
             <testcase name="test_flaky" classname="ATest" assertions="1" time="X.XX" timestamp="X.XX" flaky_test="true" run-command=\"bundle exec ruby -Ilib:test test/dummy_test.rb -n ATest\\#test_flaky\" lineno="5">
               <failure type="Minitest::Assertion" message="Expected false to be truthy.">
@@ -710,7 +722,15 @@ module Integration
           </testsuite>
           <testsuite name="BTest" filepath="test/dummy_test.rb" skipped="1" failures="0" errors="1" tests="3" assertions="1" time="X.XX">
             <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" timestamp="X.XX" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n BTest\\#test_bar" lineno="36">
-              <skipped type="TypeError"/>
+              <skipped type="TypeError" message="TypeError: String can&apos;t be coerced into Integer">
+                <![CDATA[
+        Skipped:
+        test_bar(BTest) [test/dummy_test.rb]:
+        TypeError: String can't be coerced into Integer
+            test/dummy_test.rb:37:in `+'
+            test/dummy_test.rb:37:in `test_bar'
+        ]]>
+              </skipped>
             </testcase>
             <testcase name="test_foo" classname="BTest" assertions="1" time="X.XX" timestamp="X.XX" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n BTest\\#test_foo" lineno="36"/>
             <testcase name="test_bar" classname="BTest" assertions="0" time="X.XX" timestamp="X.XX" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/dummy_test.rb -n BTest\\#test_bar" lineno="36">

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -75,7 +75,13 @@ module Minitest::Reporters
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
             <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
-              <skipped type="Minitest::Skip"/>
+              <skipped type="Minitest::Skip" message="Minitest::Skip">
+                <![CDATA[
+        Skipped:
+        test_foo(Minitest::Test) [test/my_test.rb]:
+        Minitest::Skip
+        ]]>
+              </skipped>
             </testcase>
           </testsuite>
         </testsuites>
@@ -140,7 +146,13 @@ module Minitest::Reporters
         <testsuites>
           <testsuite name="Minitest::Test" filepath="test/my_test.rb" skipped="1" failures="0" errors="0" tests="1" assertions="1" time="0.12">
             <testcase name="test_foo" classname="Minitest::Test" assertions="1" time="0.12" flaky_test="false" run-command="bundle exec ruby -Ilib:test test/my_test.rb -n Minitest::Test\\#test_foo" lineno="12">
-              <skipped type="Minitest::Assertion"/>
+              <skipped type="Minitest::Assertion" message="Failed">
+                <![CDATA[
+        Skipped:
+        test_foo(Minitest::Test) [test/my_test.rb]:
+        Failed
+        ]]>
+              </skipped>
             </testcase>
           </testsuite>
         </testsuites>


### PR DESCRIPTION
Add optional attributes message and stacktrace to skipped children in JunitXML