### PR TITLE
Pass error object to CI::Queue::Error rescue block

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -266,7 +266,7 @@ module Minitest
       reopen_previous_step
       puts red("The heartbeat process died. This worker is exiting early.")
       exit!(41)
-    rescue CI::Queue::Error
+    rescue CI::Queue::Error => error
       reopen_previous_step
       puts red("#{error.class}: #{error.message}")
       error.backtrace.each do |frame|


### PR DESCRIPTION
Fix `undefined local variable or method 'error' for module Minitest` 
The error was raised for `CI::Queue::Error` error as the error object wasn't passed to the rescue block.