### PR TITLE
Dump JSON directly to file instead of buffering

### DIFF
--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -101,11 +101,11 @@ module Minitest
       end
 
       def write_failure_file(file)
-        File.write(file, error_reports.map(&:to_h).to_json)
+        JSON.dump(error_reports.map(&:to_h), File.open(file, 'w'))
       end
 
       def write_flaky_tests_file(file)
-        File.write(file, flaky_reports.to_json)
+        JSON.dump(flaky_reports, File.open(file, 'w'))
       end
 
       private

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -323,7 +323,7 @@ module Minitest
         warnings = build.pop_warnings.map do |type, attributes|
           attributes.merge(type: type)
         end.compact
-        File.write(queue_config.warnings_file, warnings.to_json)
+        JSON.dump(warnings, File.open(queue_config.warnings_file, 'w'))
       end
 
       def run_tests_in_fork(queue)


### PR DESCRIPTION
Buffering the whole string will use much more memory, and for large test suites with lots of failures the reporter is more likely to OOM.