### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   ruby-tests:


### PR DESCRIPTION
This PR was merged with broken CI.  It didn't trigger CI because the commit was coming from a fork.

 https://github.com/Shopify/ci-queue/pull/315