### PR TITLE
Reapply "Dump JSON directly to file instead of buffering"

### DIFF
--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -107,11 +107,11 @@ module Minitest
       end
 
       def write_failure_file(file)
-        File.write(file, error_reports.map(&:to_h).to_json)
+        JSON.dump(error_reports.map(&:to_h), File.open(file, 'w'))
       end
 
       def write_flaky_tests_file(file)
-        File.write(file, flaky_reports.to_json)
+        JSON.dump(flaky_reports, File.open(file, 'w'))
       end
 
       private

--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -107,11 +107,15 @@ module Minitest
       end
 
       def write_failure_file(file)
-        JSON.dump(error_reports.map(&:to_h), File.open(file, 'w'))
+        File.open(file, 'w') do |f|
+          JSON.dump(error_reports.map(&:to_h), f)
+        end
       end
 
       def write_flaky_tests_file(file)
-        JSON.dump(flaky_reports, File.open(file, 'w'))
+        File.open(file, 'w') do |f|
+          JSON.dump(flaky_reports, f)
+        end
       end
 
       private

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -323,7 +323,7 @@ module Minitest
         warnings = build.pop_warnings.map do |type, attributes|
           attributes.merge(type: type)
         end.compact
-        File.write(queue_config.warnings_file, warnings.to_json)
+        JSON.dump(warnings, File.open(queue_config.warnings_file, 'w'))
       end
 
       def run_tests_in_fork(queue)

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -323,7 +323,9 @@ module Minitest
         warnings = build.pop_warnings.map do |type, attributes|
           attributes.merge(type: type)
         end.compact
-        JSON.dump(warnings, File.open(queue_config.warnings_file, 'w'))
+        File.open(queue_config.warnings_file, 'w') do |f|
+          JSON.dump(warnings, f)
+        end
       end
 
       def run_tests_in_fork(queue)


### PR DESCRIPTION
[Reapply "Dump JSON directly to file instead of buffering"](https://github.com/Shopify/ci-queue/commit/c4eaa5212e81d311ceee50011fcddb574a9c457e)

This reverts commit https://github.com/Shopify/ci-queue/commit/30e16eed40773b9f81074cb08fab3dfa8f322316.

---

[Use block so Files are closed after writing](https://github.com/Shopify/ci-queue/commit/80050a346e1f570868d26fa204ff485afb67900f)

This fixes test errors where the file had no content.