### PR TITLE
Specify flaky tests in junit.xml format

### DIFF
--- a/ruby/lib/ci/queue/configuration.rb
+++ b/ruby/lib/ci/queue/configuration.rb
@@ -25,7 +25,14 @@ module CI
 
         def load_flaky_tests(path)
           return [] unless path
-          ::File.readlines(path).map(&:chomp).to_set
+          if ::File.extname(path) == ".xml"
+            require 'rexml/document'
+            REXML::Document.new(::File.read(path)).elements.to_a("//testcase").map do |element|
+              "#{element.attributes['classname']}##{element.attributes['name']}"
+            end.to_set
+          else
+            ::File.readlines(path).map(&:chomp).to_set
+          end
         rescue SystemCallError
           []
         end

--- a/ruby/test/ci/queue/configuration_test.rb
+++ b/ruby/test/ci/queue/configuration_test.rb
@@ -90,6 +90,21 @@ module CI::Queue
 
       flaky_tests = Configuration.load_flaky_tests('/tmp/does-not-exist')
       assert_empty flaky_tests
+
+      Tempfile.open(['flaky_test_file', '.junit.xml']) do |file|
+        file.write(<<~XML)
+          <testsuite name="ATest">
+            <testcase name="test_foo" classname="ATest" />
+            <testcase name="test_bar" classname="ATest" />
+          </testsuite>
+        XML
+        file.close
+
+        flaky_tests = Configuration.load_flaky_tests(file.path)
+        assert_equal 2, flaky_tests.size
+        assert_includes flaky_tests, "ATest#test_foo"
+        assert_includes flaky_tests, "ATest#test_bar"
+      end
     end
 
     def test_queue_init_timeout_unset


### PR DESCRIPTION
This makes it simpler for our ci-queue client to specify the list of disabled tests.