### PR TITLE
Refactor test ACK to reduce the race condition window

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -150,6 +150,7 @@ module Minitest
     end
 
     class SingleExample
+      attr_reader :method_name
 
       def initialize(runnable, method_name)
         @runnable = runnable
@@ -250,15 +251,8 @@ module Minitest
 
         if failed && CI::Queue.requeueable?(result) && queue.requeue(example)
           result.requeue!
-          reporter.record(result)
-        elsif queue.acknowledge(example)
-          reporter.record(result)
-          queue.increment_test_failed if failed
-        elsif !failed
-          # If the test was already acknowledged by another worker (we timed out)
-          # Then we only record it if it is successful.
-          reporter.record(result)
         end
+        reporter.record(result)
       end
       queue.stop_heartbeat!
     rescue Errno::EPIPE

--- a/ruby/lib/minitest/queue/build_status_recorder.rb
+++ b/ruby/lib/minitest/queue/build_status_recorder.rb
@@ -52,7 +52,7 @@ module Minitest
         if (test.failure || test.error?) && !test.skipped?
           build.record_error("#{test.klass}##{test.name}", dump(test), stats: stats)
         else
-          build.record_success("#{test.klass}##{test.name}", stats: stats, skip_flaky_record: test.skipped?)
+          build.record_success("#{test.klass}##{test.name}", stats: stats, skip_flaky_record: test.skipped?, acknowledge: !test.requeued?)
         end
       end
 

--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -224,13 +224,8 @@ module RSpec
             reporter.cancel_run!
             dup.mark_as_requeued!(reporter)
             return true
-          elsif reporter.acknowledge || !@exception
-            # If the test was already acknowledged by another worker (we timed out)
-            # Then we only record it if it is successful.
-            super(reporter)
           else
-            reporter.cancel_run!
-            return
+            super(reporter)
           end
         else
           super(reporter)

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -514,7 +514,7 @@ module Integration
           'skips' => 0,
           'requeues' => 0,
           'total_time' => index + 1,
-        })
+        }, acknowledge: false)
       end
 
       # Retry first worker, bailing out

--- a/ruby/test/minitest/queue/build_status_recorder_test.rb
+++ b/ruby/test/minitest/queue/build_status_recorder_test.rb
@@ -15,19 +15,28 @@ module Minitest::Queue
     end
 
     def test_aggregation
+      reserve(@queue, "a")
       @reporter.record(result('a', failure: "Something went wrong"))
+      reserve(@queue, "b")
       @reporter.record(result('b', unexpected_error: true))
+      reserve(@queue, "h")
       @reporter.record(result('h', failure: "Something went wrong", requeued: true))
 
       second_queue = worker(2)
       second_reporter = BuildStatusRecorder.new(build: second_queue.build)
       second_reporter.start
 
+      reserve(second_queue, "c")
       second_reporter.record(result('c', failure: "Something went wrong"))
+      reserve(second_queue, "d")
       second_reporter.record(result('d', unexpected_error: true))
+      reserve(second_queue, "e")
       second_reporter.record(result('e', skipped: true))
+      reserve(second_queue, "f")
       second_reporter.record(result('f', unexpected_error: true))
+      reserve(second_queue, "g")
       second_reporter.record(result('g', requeued: true))
+      reserve(second_queue, "h")
       second_reporter.record(result('h', skipped: true, requeued: true))
 
       assert_equal 9, summary.assertions
@@ -40,18 +49,38 @@ module Minitest::Queue
     end
 
     def test_retrying_test
-      @reporter.record(result('a', failure: "Something went wrong"))
-      assert_equal 1, summary.error_reports.size
+      yielded = false
+
+      test = nil
+
+      @queue.poll do |_test|
+        test = _test
+        assert_equal "a", test.method_name
+        @reporter.record(result(test.method_name, failure: "Something went wrong"))
+
+        assert_equal 1, summary.error_reports.size
+
+        yielded = true
+        break
+      end
+
+      assert yielded, "@queue.poll didn't yield"
 
       second_queue = worker(2)
       second_reporter = BuildStatusRecorder.new(build: second_queue.build)
       second_reporter.start
 
-      second_reporter.record(result('a'))
+      # pretend we reserved the same test again
+      reserve(second_queue, "a")
+      second_reporter.record(result("a"))
       assert_equal 0, summary.error_reports.size
     end
 
     private
+
+    def reserve(queue, method_name)
+      queue.instance_variable_set(:@reserved_test, Minitest::Queue::SingleExample.new("Minitest::Test", method_name).id)
+    end
 
     def worker(id)
       CI::Queue::Redis.new(
@@ -61,7 +90,9 @@ module Minitest::Queue
           worker_id: id.to_s,
           timeout: 0.2,
         ),
-      ).populate([])
+      ).populate([
+        Minitest::Queue::SingleExample.new("Minitest::Test", "a")
+      ])
     end
 
     def summary


### PR DESCRIPTION
Because the `ack` and the error registration are so far apart, it's possible that the reporter exit successfully even though one test failed.

The worker first ack that the test was ran, then report the error on stdout and other places, then finally record the error in redis.

This leave a relatively big window during which the reporter might see that the queue is empty, but no errors is reported yet.

To fix that we must ack and report the error atomically, which require to move the ack inside the error reporter.

This commit doesn't fully close the race condition but make it much smaller, and make it much easier to bundle the ack and error registration in a single atomic lua script.