### PR TITLE
Make leader election idempotent

### DIFF
--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -201,7 +201,14 @@ module CI
         def push(tests)
           @total = tests.size
 
-          if @master = redis.setnx(key('master-status'), 'setup')
+          # We set a unique value (worker_id) and read it back to make "SET if Not eXists" idempotent in case of a retry.
+          value = key('setup', worker_id)
+          _, status = redis.pipelined do |pipeline|
+            pipeline.set(key('master-status'), value, nx: true)
+            pipeline.get(key('master-status'))
+          end
+
+          if @master = (value == status)
             puts "Worker electected as leader, pushing #{@total} tests to the queue."
             puts
 


### PR DESCRIPTION
`setnx` which we use during leader election is currently not safe to retry via Redis reconnect_attempts as the command could succeed on server side but we run into a client timeout. In this case, any subsequent `setnx` calls will return false and leader election will fail.

Instead we're now setting a uniq value for setup and compare it when we fail.