### PR TITLE
Fix race condition

### DIFF
--- a/redis/acknowledge.lua
+++ b/redis/acknowledge.lua
@@ -1,9 +1,18 @@
 local zset_key = KEYS[1]
 local processed_key = KEYS[2]
 local owners_key = KEYS[3]
+local error_reports_key = KEYS[4]
 
 local test = ARGV[1]
-
+local error = ARGV[2]
+local ttl = ARGV[3]
 redis.call('zrem', zset_key, test)
 redis.call('hdel', owners_key, test)  -- Doesn't matter if it was reclaimed by another workers
-return redis.call('sadd', processed_key, test)
+local acknowledged = redis.call('sadd', processed_key, test)
+
+if acknowledged and error ~= "" then
+  redis.call('hset', error_reports_key, test, error)
+  redis.call('expire', error_reports_key, ttl)
+end
+
+return acknowledged

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -181,8 +181,8 @@ module CI
           master_status == 'setup'
         end
 
-        def increment_test_failed
-          redis.incr(key('test_failed_count'))
+        def increment_test_failed(pipeline: redis)
+          pipeline.incr(key('test_failed_count'))
         end
 
         def test_failed
@@ -225,8 +225,8 @@ module CI
           redis.get(key('master-status'))
         end
 
-        def eval_script(script, *args)
-          redis.evalsha(load_script(script), *args)
+        def eval_script(script, keys:, argv:, pipeline: redis)
+          pipeline.evalsha(load_script(script), keys: keys, argv: argv)
         end
 
         def load_script(script)

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -97,12 +97,13 @@ module CI
           build.report_worker_error(error)
         end
 
-        def acknowledge(test_key)
+        def acknowledge(test_key, error: nil, pipeline: redis)
           raise_on_mismatching_test(test_key)
           eval_script(
             :acknowledge,
-            keys: [key('running'), key('processed'), key('owners')],
-            argv: [test_key],
+            keys: [key('running'), key('processed'), key('owners'), key('error-reports')],
+            argv: [test_key, error.to_s, config.redis_ttl],
+            pipeline: pipeline,
           ) == 1
         end
 

--- a/ruby/lib/ci/queue/static.rb
+++ b/ruby/lib/ci/queue/static.rb
@@ -103,12 +103,12 @@ module CI
         @queue.empty?
       end
 
-      def acknowledge(test)
+      def acknowledge(...)
         @progress += 1
         true
       end
 
-      def increment_test_failed
+      def increment_test_failed(...)
         @test_failed = test_failed + 1
       end
 


### PR DESCRIPTION
There is a small race condition between acknowledge and recording the error in which the reporter may see the queue empty and no error recorded and wrongly thinks it's a success.

Follow up from https://github.com/Shopify/ci-queue/pull/323