### PR TITLE
Return dedicated exit status

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -258,20 +258,19 @@ module Minitest
 
           unless supervisor.exhausted?
             reporter = BuildStatusReporter.new(supervisor: supervisor)
-            reporter.report
+            exit_code = reporter.report
             reporter.write_failure_file(queue_config.failure_file) if queue_config.failure_file
             reporter.write_flaky_tests_file(queue_config.export_flaky_tests_file) if queue_config.export_flaky_tests_file
 
-            abort!("#{supervisor.size} tests weren't run.")
+            abort!("#{supervisor.size} tests weren't run.", exit_code)
           end
         end
 
         reporter = BuildStatusReporter.new(supervisor: supervisor)
         reporter.write_failure_file(queue_config.failure_file) if queue_config.failure_file
         reporter.write_flaky_tests_file(queue_config.export_flaky_tests_file) if queue_config.export_flaky_tests_file
-        reporter.report
-
-        exit! reporter.success? ? 0 : 1
+        exit_code = reporter.report
+        exit! exit_code
       end
 
       def report_grind_command

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -229,6 +229,7 @@ module Integration
       end
 
       refute_predicate $?, :success?
+      assert_equal 44, $?.exitstatus
       assert_empty err
       expected = <<~EXPECTED
         Waiting for workers to complete
@@ -264,6 +265,7 @@ module Integration
       end
 
       refute_predicate $?, :success?
+      assert_equal 40, $?.exitstatus
       assert_empty err
       expected = <<~EXPECTED
         Waiting for workers to complete
@@ -1018,7 +1020,7 @@ module Integration
       assert_includes out, "Worker 1 crashed"
       assert_includes out, "Some error in the test framework"
 
-      assert_equal 1, $?.exitstatus
+      assert_equal 42, $?.exitstatus
     end
 
     private


### PR DESCRIPTION
Introducing dedicated exit status for the reporter so we can properly annotate failures which are not caused by tests. 