### PR TITLE
Fix a crash with acknowledge keyword when using static queue

### DIFF
--- a/ruby/lib/ci/queue/build_record.rb
+++ b/ruby/lib/ci/queue/build_record.rb
@@ -23,7 +23,7 @@ module CI
         record_stats(stats)
       end
 
-      def record_success(id, stats: nil, skip_flaky_record: false)
+      def record_success(id, stats: nil, skip_flaky_record: false, acknowledge: true)
         error_reports.delete(id)
         record_stats(stats)
       end

--- a/ruby/test/minitest/queue/build_status_recorder_test.rb
+++ b/ruby/test/minitest/queue/build_status_recorder_test.rb
@@ -76,6 +76,20 @@ module Minitest::Queue
       assert_equal 0, summary.error_reports.size
     end
 
+    def test_static_queue_record_success
+      static_queue = CI::Queue::Static.new(['test_example'], CI::Queue::Configuration.new(build_id: '42', worker_id: '1'))
+      static_reporter = BuildStatusRecorder.new(build: static_queue.build)
+      static_reporter.start
+
+      static_reporter.record(result('test_example'))
+
+      assert_equal 1, static_reporter.assertions
+      assert_equal 0, static_reporter.failures
+      assert_equal 0, static_reporter.errors
+      assert_equal 0, static_reporter.skips
+      assert_equal 0, static_reporter.requeues
+    end
+
     private
 
     def reserve(queue, method_name)


### PR DESCRIPTION
When running tests for `datadog-ci` gem with latest `ci-queue` I noticed the following crash:

```
ArgumentError: unknown keyword: :acknowledge
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/ci/queue/build_record.rb:26:in 'record_success'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/minitest/queue/build_status_recorder.rb:55:in 'Minitest::Queue::BuildStatusRecorder#record'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-reporters-1.7.1/lib/minitest/minitest_reporter_plugin.rb:27:in 'block in Minitest::Reporters::DelegateReporter#record'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-reporters-1.7.1/lib/minitest/minitest_reporter_plugin.rb:26:in 'Array#each'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-reporters-1.7.1/lib/minitest/minitest_reporter_plugin.rb:26:in 'Minitest::Reporters::DelegateReporter#record'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:1008:in 'block in Minitest::CompositeReporter#record'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:1007:in 'Array#each'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:1007:in 'Minitest::CompositeReporter#record'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/minitest/queue.rb:192:in 'Minitest::Queue.handle_test_result'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/minitest/queue.rb:164:in 'block (2 levels) in Minitest::Queue.run'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/ci/queue/static.rb:98:in 'CI::Queue::Static#poll'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/minitest/queue.rb:159:in 'block in Minitest::Queue.run'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/minitest/queue.rb:198:in 'Minitest::Queue.rescue_run_errors'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/minitest/queue.rb:158:in 'Minitest::Queue.run'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/ci-queue-0.68.0/lib/minitest/queue.rb:286:in 'Minitest::Queue#__run'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:288:in 'Minitest.run'
/Users/andrey.marchenko/p/datadog-ci-rb/spec/datadog/ci/contrib/ci_queue_minitest/instrumentation_spec.rb:31:in 'block (2 levels) in <top (required)>'
/Users/andrey.marchenko/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.4/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'
```

It turned out that `acknowledge` keyword was added to the redis queue, but not static queue (I use static queue in integration tests to avoid dependency on redis). This PR fixes that and provides a unit test that covers this case.