### PR TITLE
Fix ack

### DIFF
--- a/redis/acknowledge.lua
+++ b/redis/acknowledge.lua
@@ -8,7 +8,7 @@ local error = ARGV[2]
 local ttl = ARGV[3]
 redis.call('zrem', zset_key, test)
 redis.call('hdel', owners_key, test)  -- Doesn't matter if it was reclaimed by another workers
-local acknowledged = redis.call('sadd', processed_key, test)
+local acknowledged = redis.call('sadd', processed_key, test) == 1
 
 if acknowledged and error ~= "" then
   redis.call('hset', error_reports_key, test, error)


### PR DESCRIPTION
`sadd` returns the number of added entries so it always returns a truthy value. We have to `== 1`. 

This can result in race conditions for lost tests when another worker marks a lost test as processed but then fails on the original worker. 

![image](https://github.com/user-attachments/assets/cccc129d-a6fd-4233-bf54-cf11c1d86773)
