### PR TITLE
Fix race condition in success report

### DIFF
--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -881,6 +881,7 @@ module Integration
         content = File.read(flaky_tests_file)
         flaky_tests = JSON.parse(content)
         assert_includes flaky_tests, "ATest#test_flaky"
+        assert_equal 1, flaky_tests.count
       end
     end
 


### PR DESCRIPTION
In the moment we acknowledge the last test, the queue is empty. However, we haven't removed any potential error reports at this point yet. 