### PR TITLE
Make the CI Queue reporters work in parallel

### DIFF
--- a/ruby/lib/minitest/queue/order_reporter.rb
+++ b/ruby/lib/minitest/queue/order_reporter.rb
@@ -4,21 +4,29 @@ require 'minitest/reporters'
 class Minitest::Queue::OrderReporter < Minitest::Reporters::BaseReporter
   def initialize(options = {})
     @path = options.delete(:path)
+    @file = nil
     super
   end
 
   def start
-    @file = File.open(@path, 'w+')
     super
+    file.truncate(0)
   end
 
   def before_test(test)
     super
-    @file.puts("#{test.class.name}##{test.name}")
-    @file.flush
+    file.puts("#{test.class.name}##{test.name}")
+    file.flush
   end
 
   def report
-    @file.close
+    file.close
+  end
+
+  private
+
+  def file
+    @file ||= File.open(@path, 'a+')
   end
 end
+

--- a/ruby/test/integration/grind_redis_test.rb
+++ b/ruby/test/integration/grind_redis_test.rb
@@ -97,7 +97,7 @@ module Integration
 
     def test_grind_max_time
       grind_count = 1000000
-      timeout = RUBY_ENGINE == "truffleruby" ? 10 : 1
+      timeout = self.class.truffleruby? ? 10 : 1
 
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       _, err = capture_subprocess_io do

--- a/ruby/test/integration/minitest_redis_test.rb
+++ b/ruby/test/integration/minitest_redis_test.rb
@@ -673,7 +673,7 @@ module Integration
                     .sort_by { |h| "#{h[:test_id]}##{h[:test_index]}" }
                     .first
 
-      start_delta = RUBY_ENGINE == "truffleruby" ? 15 : 5
+      start_delta = self.class.truffleruby? ? 15 : 5
       assert_in_delta start_time.to_i, failure[:test_start_timestamp], start_delta, "start time"
       assert_in_delta end_time.to_i, failure[:test_finish_timestamp], 5
       assert failure[:test_finish_timestamp] > failure[:test_start_timestamp]

--- a/ruby/test/minitest/queue/order_reporter_test.rb
+++ b/ruby/test/minitest/queue/order_reporter_test.rb
@@ -7,14 +7,37 @@ module Minitest::Queue
 
     def setup
       @reporter = OrderReporter.new(path: log_path)
+    end
+
+    def test_start
       @reporter.start
+      @reporter.report
+      assert_equal [], File.readlines(log_path).map(&:chomp)
     end
 
     def test_before_test
+      @reporter.start
       @reporter.before_test(runnable('a'))
       @reporter.before_test(runnable('b'))
       @reporter.report
       assert_equal ['Minitest::Test#a', 'Minitest::Test#b'], File.readlines(log_path).map(&:chomp)
+    end
+
+    def test_forking
+      pid = fork do
+        @reporter.start
+      end
+      pids = 5.times.map do
+        fork do
+          @reporter.before_test(runnable(Process.pid))
+          @reporter.report
+        end
+      end
+      (pids + [pid]).map do |pid|
+        Process.waitpid(pid)
+      end
+
+      assert_equal pids.map { |pid| "Minitest::Test##{pid}" }.sort, File.readlines(log_path).map(&:chomp).sort
     end
 
     private

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -19,3 +19,12 @@ require 'stringio'
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].sort.each do |file|
   require file
 end
+
+
+class Minitest::Test
+  class << self
+    def truffleruby?
+      RUBY_ENGINE == "truffleruby"
+    end
+  end
+end


### PR DESCRIPTION
Make `Minitest::Queue::OrderReporter` parallel-friendly. This is essentially done by appending and truncating to the log file instead of writing to it. The object also doesn't depend on the start hook anymore to initialize the log file, because that isn't called in forked workers.