### PR TITLE
Add missing concurrent-ruby dependency

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ci-queue (0.77.0)
+      concurrent-ruby
       logger
 
 GEM

--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.add_runtime_dependency 'logger'
+  spec.add_runtime_dependency 'concurrent-ruby'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
ci-queue's recent update broke datadog-ci-rb test suite:

https://github.com/DataDog/datadog-ci-rb/actions/runs/17449737864/job/49552074849?pr=401

With the following error:
```
  cannot load such file -- concurrent/set
# /usr/local/bundle/gems/ci-queue-0.77.0/lib/ci/queue/static.rb:3:in '<top (required)>'
# /usr/local/bundle/gems/ci-queue-0.77.0/lib/ci/queue.rb:13:in '<top (required)>'
```

After PR https://github.com/Shopify/ci-queue/pull/290 `Concurrent::Set` is now used, but `concurrent-ruby` gem is not part of runtime dependencies for ci-queue. It crashes the projects that don't depend on concurrent-ruby. This PR adds missing dependency.