### PR TITLE
Prevent skipped examples from hanging rspec-queue

### DIFF
--- a/ruby/lib/rspec/queue.rb
+++ b/ruby/lib/rspec/queue.rb
@@ -226,6 +226,7 @@ module RSpec
             dup.mark_as_requeued!(reporter)
             return true
           else
+            reporter.acknowledge if skipped?
             super(reporter)
           end
         else
@@ -422,7 +423,7 @@ module RSpec
       end
 
       def acknowledge
-        @queue.acknowledge(@example)
+        @queue.acknowledge(@example.id)
       end
     end
 

--- a/ruby/test/fixtures/pending/spec/dummy_spec.rb
+++ b/ruby/test/fixtures/pending/spec/dummy_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+RSpec.describe Object do
+  it "works" do
+    expect(1 + 1).to be == 2
+  end
+
+  xit "pending 'xit' example should be ignored" do
+    expect(true).to eq false
+  end
+end

--- a/ruby/test/fixtures/pending/spec/spec_helper.rb
+++ b/ruby/test/fixtures/pending/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+RSpec.configure do |config|
+  config.backtrace_inclusion_patterns << %r{/test/fixtures/}
+end


### PR DESCRIPTION
Fixes issue with skipped examples (i.e. those written with `xit`, `xcontext`, etc.) causing the rspec-queue command to hang.

This may have been introduced in https://github.com/Shopify/ci-queue/pull/323 which looks like it removed acknowledgment of skipped examples unintentionally in this change: https://github.com/Shopify/ci-queue/pull/323/changes#diff-974bf1c9f4ea313432db2adde0f2a16f9bd0203e938d49acea6cdb5e12b69082