### PR TITLE
Cache tick! command marker to avoid per-heartbeat Symbol#to_s allocation

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.91.0)
+    ci-queue (0.92.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -266,6 +266,11 @@ module CI
         class HeartbeatProcess
           MAX_RESTART_ATTEMPTS = 3
 
+          # Cached command marker. Passing this frozen String instead of the
+          # :tick! Symbol avoids allocating a 'tick!' String (from Symbol#to_s)
+          # on every heartbeat, which fires once per running test per worker.
+          TICK_COMMAND = 'tick!'.freeze
+
           def initialize(redis_url, zset_key, owners_key, leases_key)
             @redis_url = redis_url
             @zset_key = zset_key
@@ -314,7 +319,7 @@ module CI
           end
 
           def tick!(id, lease)
-            send_message(:tick!, id: id, lease: lease.to_s)
+            send_message(TICK_COMMAND, id: id, lease: lease.to_s)
             @restart_attempts = 0
           rescue IOError, Errno::EPIPE => error
             @restart_attempts = (@restart_attempts || 0) + 1

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.91.0'
+    VERSION = '0.92.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/test/ci/queue/redis/heartbeat_process_test.rb
+++ b/ruby/test/ci/queue/redis/heartbeat_process_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'test_helper'
+require 'objspace'
 
 class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
   MAX = CI::Queue::Redis::Base::HeartbeatProcess::MAX_RESTART_ATTEMPTS
@@ -51,5 +52,44 @@ class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
     end
 
     (MAX + 1).times { @hp.tick!("test_id", "lease_id") }
+  end
+
+  def test_tick_does_not_allocate_tick_marker_string
+    @hp.instance_variable_set(:@pipe, StringIO.new)
+    @hp.tick!("test_id", "lease_id") # warm up any one-time caches
+
+    ObjectSpace.trace_object_allocations_start
+    begin
+      @hp.tick!("test_id", "lease_id")
+    ensure
+      ObjectSpace.trace_object_allocations_stop
+    end
+
+    tick_allocations = []
+    ObjectSpace.each_object(String) do |s|
+      next unless s == "tick!"
+      file = ObjectSpace.allocation_sourcefile(s)
+      next unless file # already-allocated strings have no source
+      tick_allocations << [file, ObjectSpace.allocation_sourceline(s)]
+    end
+
+    assert_empty tick_allocations,
+      "A 'tick!' String was allocated per heartbeat tick — the command marker should be cached as a frozen String"
+  ensure
+    ObjectSpace.trace_object_allocations_clear
+  end
+
+  def test_tick_sends_valid_tick_payload
+    pipe = StringIO.new
+    @hp.instance_variable_set(:@pipe, pipe)
+
+    @hp.tick!("test_id", "lease_id")
+
+    raw = pipe.string
+    header_size = [0].pack("L").bytesize
+    size = raw.byteslice(0, header_size).unpack1("L")
+    payload = raw.byteslice(header_size, size)
+
+    assert_equal ["tick!", { "id" => "test_id", "lease" => "lease_id" }], JSON.parse(payload)
   end
 end

--- a/ruby/test/ci/queue/redis/heartbeat_process_test.rb
+++ b/ruby/test/ci/queue/redis/heartbeat_process_test.rb
@@ -5,6 +5,22 @@ require 'objspace'
 class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
   MAX = CI::Queue::Redis::Base::HeartbeatProcess::MAX_RESTART_ATTEMPTS
 
+  # StringIO#write only accepts a single argument on TruffleRuby, so we fake a
+  # pipe that supports the multi-argument IO#write signature the production
+  # code relies on.
+  class FakePipe
+    attr_reader :buffer
+
+    def initialize
+      @buffer = +"".b
+    end
+
+    def write(*parts)
+      parts.each { |part| @buffer << part.b }
+      @buffer.bytesize
+    end
+  end
+
   def setup
     @hp = CI::Queue::Redis::Base::HeartbeatProcess.new(
       'redis://localhost:6379/0',
@@ -55,7 +71,7 @@ class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
   end
 
   def test_tick_does_not_allocate_tick_marker_string
-    @hp.instance_variable_set(:@pipe, StringIO.new)
+    @hp.instance_variable_set(:@pipe, FakePipe.new)
     @hp.tick!("test_id", "lease_id") # warm up any one-time caches
 
     ObjectSpace.trace_object_allocations_start
@@ -80,12 +96,12 @@ class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
   end
 
   def test_tick_sends_valid_tick_payload
-    pipe = StringIO.new
+    pipe = FakePipe.new
     @hp.instance_variable_set(:@pipe, pipe)
 
     @hp.tick!("test_id", "lease_id")
 
-    raw = pipe.string
+    raw = pipe.buffer
     header_size = [0].pack("L").bytesize
     size = raw.byteslice(0, header_size).unpack1("L")
     payload = raw.byteslice(header_size, size)


### PR DESCRIPTION
## Summary

- `HeartbeatProcess#tick!` passes `:tick!` as a Symbol into `send_message`, where `message.to_json` allocates a fresh `'tick!'` String from `Symbol#to_s` on every heartbeat. This fires once per running test per worker and shows up in downstream gems that count allocations.
- Replace the Symbol with a frozen String constant (`TICK_COMMAND = 'tick!'.freeze`) so no `'tick!'` String is allocated per tick. JSON wire format is unchanged — the monitor child still receives `["tick!", {"id": ..., "lease": ...}]`.
- Add a regression test using `ObjectSpace.trace_object_allocations` that asserts no `'tick!'` String is allocated inside `tick!`, plus a round-trip test confirming the payload parses back to the expected structure.
- Bump to v0.92.0.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/ci/queue/redis/heartbeat_process_test.rb` — all 7 tests pass
- [x] New no-alloc test fails on `main` (confirmed with the pre-fix code) and passes after the fix
- [x] Full suite has no new failures vs `main` (pre-existing failures are Redis connection errors and unrelated bisect fixture mismatches)