### PR TITLE
Fix UnresolvedEntry error

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.92.0)
+    ci-queue (0.93.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.92.0'
+    VERSION = '0.93.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -115,6 +115,8 @@ module Minitest
             puts "#{remaining} tests left and #{running} workers running."
             if remaining <= running
               puts green("Queue almost empty, exiting early...")
+              verify_reporters!(reporters)
+              exit!(0)
             else
               prepare_queue_for_execution
             end

--- a/ruby/test/ci/queue/redis_test.rb
+++ b/ruby/test/ci/queue/redis_test.rb
@@ -687,6 +687,10 @@ class CI::Queue::RedisTest < Minitest::Test
     w1 = worker(1, tests: test_list, build_id: 'self-requeue', timeout: 10, max_requeues: 1, requeue_tolerance: 1.0)
     w2 = worker(2, populate: false, build_id: 'self-requeue', timeout: 10, max_requeues: 1, requeue_tolerance: 1.0)
     w3 = worker(3, populate: false, build_id: 'self-requeue', timeout: 10, max_requeues: 1, requeue_tolerance: 1.0)
+    # Identity resolver so poll yields the raw queue entry (poll now skips
+    # UnresolvedEntry values, and these workers don't share w1's @index).
+    w2.entry_resolver = ->(entry) { entry }
+    w3.entry_resolver = ->(entry) { entry }
     w2.send(:register)
     w3.send(:register)
 


### PR DESCRIPTION
A worker whose queue has neither `@index` nor `entry_resolver` set was yielding `UnresolvedEntry` (a `Struct.new(:id, :queue_entry)` with no `.run`) from `Worker#poll`. The Minitest adapter called `example.run` on it, raised `NoMethodError`, `rescue_run_errors` caught it, and the worker exited with code 42. The report step then saw `worker_errors` non-empty and failed the build — cascading into ~150 downstream broken jobs even though 597k tests passed.

Repro: world-shopify-selective-tests #936469, summary job `019dae91-8271-4b54-a31d-2ed49491de24` (ci-queue 0.90.0).

How a worker reaches this state: `runner.rb#run_command`'s `retry? && remaining <= running` "Queue almost empty, exiting early..." branch skips `prepare_queue_for_execution` but falls through to `Minitest.run []`, which invokes `queue.poll` on a queue that was never populated or configured with a resolver. `reserve` can still pick up a lost test (via `reserve_lost`) and return an entry that `resolve_entry` has no way to turn into a runnable.

## Fix

Primary, in `Worker#poll`: when `resolve_entry` returns an `UnresolvedEntry`, acknowledge the entry and `next` instead of yielding it. The test is released so another worker (or the heartbeat reclaimer) can handle it.

Defense in depth, in the Minitest and RSpec adapters: `next unless example.respond_to?(:run)` inside the `queue.poll` block — an unexpected queue state should never crash a worker.

## Test plan

- [x] New unit test `test_poll_skips_unresolved_entries_without_crashing` pushes a raw entry onto a worker with no `@index` and no `entry_resolver`, polls, and asserts nothing is yielded and the queue exhausts. Without the `poll` fix this test hangs (entry yielded but never acknowledged → `exhausted?` never true).
- [x] Existing `resolve_entry` and retry-with-entry-resolver tests still pass.

## Follow-up (out of scope)

- `BuildStatusReporter#success?` should not treat a single `worker_errors` entry as build-failing when `error_reports.empty? && queue_exhausted? && !timed_out?` — surface as a warning instead.
- Optional: `runner.rb`'s "Queue almost empty" branch could `exit!(0)` instead of falling through to `Minitest.run []`. The poll-level fix makes this harmless, but it's the cleaner root-level exit.