### PR TITLE
Scrub invalid UTF-8 in FailureFormatter#to_s

### DIFF
--- a/ruby/lib/minitest/queue/failure_formatter.rb
+++ b/ruby/lib/minitest/queue/failure_formatter.rb
@@ -15,6 +15,7 @@ module Minitest
       def to_s
         s = +"#{header}\n#{body}\n\n"
         s.encode!(Encoding::UTF_8, invalid: :replace, undef: :replace)
+        s.scrub!
         s
       end
 

--- a/ruby/test/minitest/queue/failure_formatter_test.rb
+++ b/ruby/test/minitest/queue/failure_formatter_test.rb
@@ -6,12 +6,60 @@ module Minitest::Queue
   class FailureFormatterTest < Minitest::Test
     include ReporterTestHelper
 
-    def test_failure_formatter_to_h_can_be_json_dumped
-      test = result('test_json', failure: "\xD6".b)
-
+    def test_to_s_and_to_h_with_valid_utf8
+      test = result('test_valid', failure: "assertion failed: expected \u2603")
       formatter = FailureFormatter.new(test)
 
-      assert JSON.dump(formatter.to_h)
+      assert_predicate(formatter.to_s, :valid_encoding?)
+      assert_includes(formatter.to_s, "assertion failed: expected \u2603")
+      assert(JSON.dump(formatter.to_h))
+    end
+
+    def test_to_s_and_to_h_with_ascii_8bit_failure
+      test = result('test_json', failure: "\xD6".b)
+      formatter = FailureFormatter.new(test)
+
+      assert_predicate(formatter.to_s, :valid_encoding?)
+      assert(JSON.dump(formatter.to_h))
+    end
+
+    def test_to_s_and_to_h_with_utf8_tagged_invalid_bytes
+      # Mirror the production trigger: a UTF-8-tagged string containing invalid byte
+      # sequences. encode!(UTF_8, ...) is a no-op when source == dest encoding, so
+      # without scrub! these bytes pass through and crash JSON.dump.
+      invalid_utf8 = "boom \xE1\x02\xFF tail".dup.force_encoding(Encoding::UTF_8)
+      refute_predicate(invalid_utf8, :valid_encoding?)
+
+      test = result('test_json_utf8_tagged', failure: invalid_utf8)
+      formatter = FailureFormatter.new(test)
+
+      assert_predicate(formatter.to_s, :valid_encoding?)
+      assert_includes(formatter.to_s, "tail")
+      assert(JSON.dump(formatter.to_h))
+    end
+
+    def test_to_s_and_to_h_with_iso_8859_1_failure
+      # encode! transcodes non-UTF-8 sources; verify the character is preserved.
+      iso_message = "expected \xD6sterreich".dup.force_encoding(Encoding::ISO_8859_1)
+      test = result('test_iso', failure: iso_message)
+      formatter = FailureFormatter.new(test)
+
+      assert_predicate(formatter.to_s, :valid_encoding?)
+      assert_includes(formatter.to_s, "\u00D6sterreich")
+      assert(JSON.dump(formatter.to_h))
+    end
+
+    def test_to_s_and_to_h_with_unexpected_error_containing_invalid_bytes
+      error = StandardError.new("binary payload \xC0\xFF".b)
+      error.set_backtrace(["test.rb:1:in `test'"])
+      unexpected = Minitest::UnexpectedError.new(error)
+
+      test = result('test_unexpected', failure: unexpected)
+      formatter = FailureFormatter.new(test)
+
+      assert_predicate(formatter.to_s, :valid_encoding?)
+      assert_includes(formatter.to_s, "StandardError")
+      assert(JSON.dump(formatter.to_h))
     end
   end
 end


### PR DESCRIPTION
## Problem

`Minitest::Queue::FailureFormatter#to_s` uses `String#encode!(Encoding::UTF_8, invalid: :replace, undef: :replace)` to sanitize test output before it gets JSON-serialized in `BuildStatusReporter#write_failure_file`. Per the Ruby docs, `encode!` is a no-op when the source and destination encodings are the same. When test output contains a UTF-8-tagged string with invalid byte sequences — common when WebMock surfaces a protobuf request body in an error message — the call silently leaves the bad bytes intact.

`JSON.dump` then crashes with `Encoding::UndefinedConversionError`, and the entire `minitest-queue report` step exits before writing any failure file. Builds with many failures lose every single failure record, breaking flake-triage workflows.

## Fix

Add `scrub!` after `encode!` to catch the case `encode!` misses. `encode!` still handles transcoding from non-UTF-8 sources (ASCII-8BIT, ISO-8859-1, etc.), and `scrub!` cleans any remaining invalid byte sequences in UTF-8-tagged strings. Both use the same default replacement character (`U+FFFD`).

## Reference

Original ASCII-8BIT fix: https://github.com/Shopify/ci-queue/commit/ed4ae2608f09f862e1edfdf10f1f104e95dbe630 — this PR closes the remaining gap.

Closes https://github.com/shop/issues/issues/39402

co-authored by AI