### PR TITLE
Bump ci-queue to v0.93.0

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.92.0)
+    ci-queue (0.93.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.92.0'
+    VERSION = '0.93.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end


### PR DESCRIPTION
Version bump to release the invalid UTF-8 scrubbing fix in `FailureFormatter#to_s` (#403). Without this fix, `BuildStatusReporter#write_failure_file` crashes with `Encoding::UndefinedConversionError` when test output contains UTF-8-tagged strings with invalid byte sequences, losing all failure records for the build.

co-authored by AI