### PR TITLE
Make HeartbeatProcess#tick! lease argument backward-compatible

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.93.0)
+    ci-queue (0.94.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue/redis/base.rb
+++ b/ruby/lib/ci/queue/redis/base.rb
@@ -318,8 +318,10 @@ module CI
             end
           end
 
-          def tick!(id, lease)
-            send_message(TICK_COMMAND, id: id, lease: lease.to_s)
+          def tick!(id, lease = nil)
+            payload = { id: id }
+            payload[:lease] = lease.to_s if lease
+            send_message(TICK_COMMAND, **payload)
             @restart_attempts = 0
           rescue IOError, Errno::EPIPE => error
             @restart_attempts = (@restart_attempts || 0) + 1

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.93.0'
+    VERSION = '0.94.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/test/ci/queue/redis/heartbeat_process_test.rb
+++ b/ruby/test/ci/queue/redis/heartbeat_process_test.rb
@@ -21,6 +21,18 @@ class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
     end
   end
 
+  class PipedHeartbeatProcess < CI::Queue::Redis::Base::HeartbeatProcess
+    attr_reader :pipe
+
+    def initialize(pipe, *args)
+      super(*args)
+      @pipe = pipe
+    end
+
+    def boot!; end
+    def restart!; end
+  end
+
   def setup
     @hp = CI::Queue::Redis::Base::HeartbeatProcess.new(
       'redis://localhost:6379/0',
@@ -71,12 +83,12 @@ class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
   end
 
   def test_tick_does_not_allocate_tick_marker_string
-    @hp.instance_variable_set(:@pipe, FakePipe.new)
-    @hp.tick!("test_id", "lease_id") # warm up any one-time caches
+    hp = PipedHeartbeatProcess.new(FakePipe.new, 'redis://localhost:6379/0', 'zset', 'owners', 'leases')
+    hp.tick!("test_id", "lease_id") # warm up any one-time caches
 
     ObjectSpace.trace_object_allocations_start
     begin
-      @hp.tick!("test_id", "lease_id")
+      hp.tick!("test_id", "lease_id")
     ensure
       ObjectSpace.trace_object_allocations_stop
     end
@@ -97,15 +109,29 @@ class CI::Queue::Redis::Base::HeartbeatProcessTest < Minitest::Test
 
   def test_tick_sends_valid_tick_payload
     pipe = FakePipe.new
-    @hp.instance_variable_set(:@pipe, pipe)
+    hp = PipedHeartbeatProcess.new(pipe, 'redis://localhost:6379/0', 'zset', 'owners', 'leases')
 
-    @hp.tick!("test_id", "lease_id")
+    hp.tick!("test_id", "lease_id")
 
     raw = pipe.buffer
     header_size = [0].pack("L").bytesize
     size = raw.byteslice(0, header_size).unpack1("L")
     payload = raw.byteslice(header_size, size)
 
-    assert_equal ["tick!", { "id" => "test_id", "lease" => "lease_id" }], JSON.parse(payload)
+    assert_equal(["tick!", { "id" => "test_id", "lease" => "lease_id" }], JSON.parse(payload))
+  end
+
+  def test_tick_without_lease_omits_lease_from_payload
+    pipe = FakePipe.new
+    hp = PipedHeartbeatProcess.new(pipe, 'redis://localhost:6379/0', 'zset', 'owners', 'leases')
+
+    hp.tick!("test_id")
+
+    raw = pipe.buffer
+    header_size = [0].pack("L").bytesize
+    size = raw.byteslice(0, header_size).unpack1("L")
+    payload = raw.byteslice(header_size, size)
+
+    assert_equal(["tick!", { "id" => "test_id" }], JSON.parse(payload))
   end
 end


### PR DESCRIPTION
The `lease` parameter was added to `HeartbeatProcess#tick!` in v0.85.0, changing the signature from 1 argument to 2. Callers still using the old 1-argument signature crash with `ArgumentError: wrong number of arguments (given 1, expected 2)` when upgrading.

Make `lease` optional so both call sites work. When omitted, `lease` is excluded from the heartbeat payload entirely, matching the pre-v0.85.0 wire format.

Also cleans up `instance_variable_set` usage in the heartbeat tests by introducing a `PipedHeartbeatProcess` test subclass with proper constructor injection.

co-authored by AI