### PR TITLE
add compatibility for minitest 6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,13 @@ jobs:
           - '3.4'
           - '4.0'
           - 'truffleruby'
+        minitest:
+          - '~> 5.11'
+          - '~> 6.0'
+        exclude:
+          # minitest 6 requires Ruby >= 3.2
+          - ruby: '3.1'
+            minitest: '~> 6.0'
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
@@ -38,6 +45,7 @@ jobs:
         env:
           SUITE: ruby
           REDIS_HOST: localhost
+          MINITEST_VERSION: ${{ matrix.minitest }}
 
   python-tests:
     runs-on: ubuntu-latest

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     minitest (5.27.0)
+    minitest-mock (5.27.0)
     minitest-reporters (1.7.1)
       ansi
       builder
@@ -106,6 +107,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -113,7 +115,8 @@ DEPENDENCIES
   benchmark
   bundler
   ci-queue!
-  minitest (~> 5.11)
+  minitest (>= 5.11)
+  minitest-mock
   minitest-reporters (~> 1.1)
   mocha
   msgpack

--- a/ruby/ci-queue.gemspec
+++ b/ruby/ci-queue.gemspec
@@ -35,11 +35,12 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '~> 5.11')
+  spec.add_development_dependency 'minitest', ENV.fetch('MINITEST_VERSION', '>= 5.11')
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'redis'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'minitest-reporters', '~> 1.1'
+  spec.add_development_dependency 'minitest-mock'
   spec.add_development_dependency 'mocha'
 
   spec.add_development_dependency 'rexml'

--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -359,7 +359,7 @@ module Minitest
 
       def run
         with_timestamps do
-          Minitest.run_one_method(@runnable, @method_name)
+          @runnable.new(@method_name).run
         end
       end
 
@@ -450,7 +450,7 @@ module Minitest
           elsif skip_stale_tests? && !(runnable.method_defined?(@method_name) || runnable.private_method_defined?(@method_name))
             build_stale_skip_result
           else
-            Minitest.run_one_method(runnable, @method_name)
+            runnable.new(@method_name).run
           end
         rescue StandardError, ScriptError => error
           build_error_result(error)
@@ -552,6 +552,12 @@ module Minitest
       Reporters.use!(((Reporters.reporters || []) - @queue_reporters) + reporters)
       Minitest.backtrace_filter.add_filter(%r{exe/minitest-queue|lib/ci/queue/})
       @queue_reporters = reporters
+
+      # minitest 6 made plugin loading opt-in (no longer called from
+      # Minitest.run). Ensure minitest-reporters' plugin is loaded so
+      # that its DelegateReporter wires our reporters into the
+      # CompositeReporter that Minitest.run creates.
+      Minitest.load_plugins if Minitest.respond_to?(:load_plugins)
     end
 
     def loaded_tests
@@ -562,19 +568,34 @@ module Minitest
       end
     end
 
-    def __run(*args)
-      if queue
-        Queue.run(*args)
+    # minitest 5 calls __run; minitest 6 renamed it to run_all_suites.
+    # Define both so the prepend intercepts whichever version is active.
+    %i[__run run_all_suites].each do |name|
+      define_method(name) do |*args|
+        if queue
+          Queue.run(*args)
 
-        if queue.config.circuit_breakers.any?(&:open?)
-          STDERR.puts queue.config.circuit_breakers.map(&:message).join(' ').strip
-        end
+          if queue.config.circuit_breakers.any?(&:open?)
+            STDERR.puts queue.config.circuit_breakers.map(&:message).join(' ').strip
+          end
 
-        if queue.max_test_failed?
-          STDERR.puts 'This worker is exiting early because too many failed tests were encountered.'
+          if queue.max_test_failed?
+            STDERR.puts 'This worker is exiting early because too many failed tests were encountered.'
+          end
+
+          # minitest 6 starts a Parallel::Executor thread pool before
+          # calling run_all_suites, then joins those threads in shutdown
+          # afterward. ci-queue bypasses the executor entirely (it has
+          # its own Redis poll loop), so the worker threads sit idle and
+          # shutdown hangs forever. Drain them here so the later
+          # shutdown in Minitest.run is a no-op.
+          if Minitest.respond_to?(:parallel_executor)
+            executor = Minitest.parallel_executor
+            executor.shutdown if executor.respond_to?(:shutdown)
+          end
+        else
+          super(*args)
         end
-      else
-        super
       end
     end
   end

--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -393,6 +393,7 @@ module Minitest
         child_pid = fork do
           Minitest.queue = queue
           Minitest::Reporters.use!([Minitest::Reporters::BisectReporter.new])
+          Minitest.load_plugins if Minitest.respond_to?(:load_plugins)
           exit # let minitest excute its at_exit
         end
 

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -9,6 +9,14 @@ require 'ci/queue'
 require 'ci/queue/redis'
 require 'minitest/queue'
 require 'minitest/autorun'
+
+# minitest 6 extracted mock into a separate gem
+begin
+  require 'minitest/mock'
+rescue LoadError
+  require 'minitest-mock'
+end
+
 require 'mocha/minitest'
 
 Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])


### PR DESCRIPTION
minitest 6.0 shipped [breaking API changes](https://minite.st/docs/History_rdoc.html#600--2025-12-17) that affect ci-queue. This PR adds minitest 6 support while remaining backwards compatible with minitest 5.11+.

   ### Breaking changes in minitest 6

   **1. `Minitest.run_one_method(klass, name)` — removed**

   ci-queue used this to run individual tests in `SingleExample#run` and `LazySingleExample#run`. Replaced with `klass.new(name).run` which works on both minitest 5 and 6.

   **2. `Minitest.__run` — renamed to `Minitest.run_all_suites`**

   ci-queue prepends a module onto `Minitest`'s singleton class to override `__run` with its Redis-backed poll loop. minitest 6 renamed this method, so the override no longer fires. We now define both `__run` and `run_all_suites` on the prepended module — only the one matching the active minitest version is called;
 the other is inert.

   **3. Plugin loading — now opt-in**

   minitest 5 auto-discovered plugins via `load_plugins` inside `Minitest.run`. minitest 6 removed this. Without it, `minitest-reporters`' `plugin_minitest_reporter_init` never fires, so its `DelegateReporter` is never created. This meant ci-queue's reporters (including `BuildStatusRecorder`) were set in
 `Minitest::Reporters.reporters` but never wired into the `CompositeReporter` that `Minitest.run` actually calls `record` on.

   The consequence: `BuildStatusRecorder#record` never ran → `acknowledge` never called → Redis running set never cleared → `exhausted?` never returned true → **the poll loop hung forever**.

   Fixed by calling `Minitest.load_plugins` explicitly when ci-queue sets up its reporters, and in `run_tests_in_fork` (used by bisect).

   **4. `Parallel::Executor` thread pool**

   minitest 6 starts N threads (where N = CPU count) before `run_all_suites` and joins them afterward via `shutdown`. ci-queue bypasses the executor entirely — it has its own Redis poll loop — so those threads sit idle on `queue.pop` and `shutdown` blocks forever. We now drain the executor after `Queue.run`
 completes.

   ### Backwards compatibility

   All changes are guarded by `respond_to?` checks. No version string comparisons. minitest 5.11+ continues to work unchanged.