### PR TITLE
Bump ci-queue to v0.94.0

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.93.0)
+    ci-queue (0.94.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.93.0'
+    VERSION = '0.94.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end


### PR DESCRIPTION
Bumping ci-queue to v0.94.0 to release the minitest 6 compatibility added in #407.  Without these changes applications cannot use minitest 6.