### PR TITLE
fix: do not exit non-zero on inconclusive bisect

### DIFF
--- a/ruby/lib/minitest/queue/runner.rb
+++ b/ruby/lib/minitest/queue/runner.rb
@@ -254,7 +254,9 @@ module Minitest
           step(yellow("The failing test was the first test in the test order so there is nothing to bisect."))
           File.write('log/test_order.log', "")
           File.write('log/bisect_test_details.log', "")
-          exit! 1
+          # Bisect ran successfully; there is simply nothing to bisect against.
+          # Reserve non-zero exits for cases where the bisect could not run (see failing_test_present? above).
+          exit! 0
         end
 
         failing_order = queue.candidates
@@ -263,7 +265,10 @@ module Minitest
           step(yellow("The bisection was inconclusive, there might not be any leaky test here."))
           File.write('log/test_order.log', "")
           File.write('log/bisect_test_details.log', "")
-          exit! 1
+          # Bisect ran successfully; the failure did not reproduce on the narrowed-down order.
+          # This is the expected outcome for genuinely flaky tests (timing/async) rather than order-dependent ones.
+          # Reserve non-zero exits for cases where the bisect could not run.
+          exit! 0
         else
           step(green('The following command should reproduce the leak on your machine:'), collapsed: false)
           command = %w(bundle exec minitest-queue --queue - run)

--- a/ruby/test/integration/minitest_bisect_test.rb
+++ b/ruby/test/integration/minitest_bisect_test.rb
@@ -11,10 +11,12 @@ module Integration
     end
 
     def test_bisect
+      result = nil
       out, err = capture_subprocess_io do
-        run_bisect('log/leaky_test_order.log', 'LeakyTest#test_sensible_to_leak')
+        result = run_bisect('log/leaky_test_order.log', 'LeakyTest#test_sensible_to_leak')
       end
 
+      assert_equal true, result, "bisect should exit 0 when a leaky test is identified"
       assert_empty filter_deprecation_warnings(err)
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
@@ -101,10 +103,12 @@ module Integration
     end
 
     def test_inconclusive
+      result = nil
       out, err = capture_subprocess_io do
-        run_bisect('log/unconclusive_test_order.log', 'LeakyTest#test_sensible_to_leak')
+        result = run_bisect('log/unconclusive_test_order.log', 'LeakyTest#test_sensible_to_leak')
       end
 
+      assert_equal true, result, "inconclusive bisect should exit 0; it ran successfully and reported a valid diagnostic outcome"
       assert_empty filter_deprecation_warnings(err)
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
@@ -178,10 +182,12 @@ module Integration
     end
 
     def test_failing_test_is_the_first_entry_in_the_test_order
+      result = nil
       out, err = capture_subprocess_io do
-        run_bisect('log/unconclusive_test_order.log', 'LeakyTest#test_useless_0')
+        result = run_bisect('log/unconclusive_test_order.log', 'LeakyTest#test_useless_0')
       end
 
+      assert_equal true, result, "should exit 0 when there is nothing to bisect; the run completed normally"
       assert_empty filter_deprecation_warnings(err)
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
@@ -193,10 +199,12 @@ module Integration
     end
 
     def test_broken_tests_which_are_not_evaluated_are_ignored
+      result = nil
       out, err = capture_subprocess_io do
-        run_bisect('log/leaky_with_broken_test_order.log', 'LeakyTest#test_sensible_to_leak')
+        result = run_bisect('log/leaky_with_broken_test_order.log', 'LeakyTest#test_sensible_to_leak')
       end
 
+      assert_equal true, result, "inconclusive bisect should exit 0 even when broken tests are skipped along the way"
       assert_empty filter_deprecation_warnings(err)
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
@@ -270,10 +278,12 @@ module Integration
     end
 
     def test_broken
+      result = nil
       out, err = capture_subprocess_io do
-        run_bisect('log/broken_test_order.log', 'LeakyTest#test_broken_test')
+        result = run_bisect('log/broken_test_order.log', 'LeakyTest#test_broken_test')
       end
 
+      assert_equal true, result, "should exit 0 when the failing test fails in isolation; bisect ran and produced a useful diagnostic"
       assert_empty filter_deprecation_warnings(err)
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation
@@ -287,10 +297,12 @@ module Integration
     end
 
     def test_failing_test_is_not_present
+      result = nil
       out, err = capture_subprocess_io do
-        run_bisect('log/leaky_test_order.log', 'LeakyTestDoesNotExist#test_sensible_to_leak')
+        result = run_bisect('log/leaky_test_order.log', 'LeakyTestDoesNotExist#test_sensible_to_leak')
       end
 
+      assert_equal false, result, "should exit non-zero when the failing test cannot be found; the run could not actually execute"
       assert_empty filter_deprecation_warnings(err)
       expected_output = strip_heredoc <<-EOS
         --- Testing the failing test in isolation


### PR DESCRIPTION
## Summary

Treat inconclusive bisects as a successful diagnostic outcome instead of a build failure. Reserve non-zero exits for cases where bisect could not actually run.

## Motivation

`bisect_command` currently `exit! 1` in two cases that represent successful diagnostic runs:

1. **`"The bisection was inconclusive, there might not be any leaky test here."`** — bisect ran, narrowed candidates, and on final validation the failure did not reproduce on the narrowed-down order. This is the expected outcome for genuinely flaky tests (timing, async, network) rather than order-dependent ones.
2. **`"The failing test was the first test in the test order so there is nothing to bisect."`** — bisect ran and reported that there are no preceding tests to suspect.

Both are valid findings produced by a successful run, not failures.

In practice, callers wire `rake test:bisect` (or `minitest-queue ... bisect` directly) into a pipeline that runs leakbot on each detected flaky test. Most flaky tests in a large Rails codebase are flaky for non-order-dependent reasons (timing, shared external state, async). Bisect correctly returns "inconclusive" for those, but the non-zero exit code makes the pipeline report the run as failed even though bisect did exactly what it was supposed to do.

This also makes it impossible to distinguish these legitimate outcomes from genuine harness failures — for example, the lazy_load + non-streaming-queue regression fixed in #400, where bisect bailed immediately with `"The failing test does not exist."` because `Minitest.loaded_tests` was empty. Both surfaced as exit 1, so callers had no way to tell "bisect could not run" from "bisect ran and found nothing to pin down."

## Changes

After this PR:

| Outcome | Exit code |
|---|---|
| Polluter found | 0 |
| Failing test fails in isolation | 0 |
| Inconclusive (failure did not reproduce) | **0 (was 1)** |
| Nothing to bisect (failing test is first) | **0 (was 1)** |
| `FAILING_TEST` missing / not present in the queue | 1 |
| Missing arguments | 1 |

In short: **exit 0 when bisect ran to completion, regardless of outcome. Exit non-zero only when bisect could not run.**

The integration tests in `test/integration/minitest_bisect_test.rb` are updated to assert the new exit-code contract for each scenario.

## Notes

- User-visible output (the colored step lines, `log/test_order.log`, `log/bisect_test_details.log`) is unchanged, so callers can still distinguish outcomes by reading those if they care.
- This is a behavior change for any caller that today reads exit code 1 as "no polluter found." I'm not aware of any — the typical caller is a CI step wrapper that just propagates the exit code as build status.

cc @andheiberg — follow-up to #400.