### PR TITLE
fix incomplete file

### DIFF
--- a/ruby/lib/minitest/queue/junit_reporter.rb
+++ b/ruby/lib/minitest/queue/junit_reporter.rb
@@ -3,6 +3,7 @@
 require 'minitest/reporters'
 require 'rexml/document'
 require 'fileutils'
+require 'tempfile'
 
 module Minitest
   module Queue
@@ -40,9 +41,16 @@ module Minitest
       def report
         super
 
-        FileUtils.mkdir_p(File.dirname(@report_path))
-        File.open(@report_path, 'w+') do |file|
-          format_document(generate_document, file)
+        dir = File.dirname(@report_path)
+        FileUtils.mkdir_p(dir)
+        tmp = Tempfile.new([File.basename(@report_path), '.tmp'], dir)
+        begin
+          format_document(generate_document, tmp)
+          tmp.close
+          File.rename(tmp.path, @report_path)
+        rescue
+          tmp.close!
+          raise
         end
       end
 

--- a/ruby/test/minitest/reporters/junit_reporter_test.rb
+++ b/ruby/test/minitest/reporters/junit_reporter_test.rb
@@ -175,6 +175,52 @@ module Minitest::Reporters
       end
     end
 
+    def test_report_writes_file_atomically
+      Dir.mktmpdir do |dir|
+        report_path = File.join(dir, 'junit.xml')
+        reporter = Minitest::Queue::JUnitReporter.new(report_path)
+        reporter.start
+        reporter.record(result("test_foo"))
+        reporter.report
+
+        assert File.exist?(report_path), "expected report file to exist"
+        contents = File.read(report_path)
+        assert_includes contents, '</testsuites>'
+        assert_empty Dir.glob(File.join(dir, '*.tmp*')), "no tempfile should be left behind"
+      end
+    end
+
+    def test_report_does_not_leave_partial_file_on_error
+      Dir.mktmpdir do |dir|
+        report_path = File.join(dir, 'junit.xml')
+        reporter = Minitest::Queue::JUnitReporter.new(report_path)
+        reporter.start
+        reporter.record(result("test_foo"))
+
+        reporter.define_singleton_method(:format_document) do |_doc, _io|
+          raise IOError, "simulated mid-write crash"
+        end
+
+        assert_raises(IOError) { reporter.report }
+
+        refute File.exist?(report_path), "no partial file should remain at the report path"
+        assert_empty Dir.glob(File.join(dir, '*.tmp*')), "no orphaned tempfile should remain"
+      end
+    end
+
+    def test_report_creates_parent_directories
+      Dir.mktmpdir do |dir|
+        report_path = File.join(dir, 'nested', 'deeper', 'junit.xml')
+        reporter = Minitest::Queue::JUnitReporter.new(report_path)
+        reporter.start
+        reporter.record(result("test_foo"))
+        reporter.report
+
+        assert File.exist?(report_path), "expected report file to exist in nested dir"
+        assert_includes File.read(report_path), '</testsuites>'
+      end
+    end
+
     private
 
     def generate_xml(junitxml)


### PR DESCRIPTION
### TL;DR

JUnit report files are now written atomically using a temporary file and rename.

### What changed?

The `JUnitReporter#report` method now writes the XML output to a temporary file in the same directory as the target report path, then atomically renames it to the final destination. If an error occurs during writing, the temporary file is cleaned up and no partial file is left at the report path.

### How to test?

Three new test cases cover the updated behavior:
- **Atomic write**: Verifies the report file is written successfully and no `.tmp` files are left behind after a normal run.
- **Error handling**: Simulates a mid-write crash and asserts that neither a partial report file nor an orphaned temp file remains.
- **Nested directories**: Confirms that parent directories are still created when they don't exist.

### Why make this change?

Previously, a crash or error mid-write could leave a partial or corrupt XML file at the report path. By writing to a temp file first and renaming only on success, the final report file is either fully written or absent — preventing downstream consumers from reading incomplete JUnit output.