### PR TITLE
Bump ci-queue to v0.96.0

### DIFF
--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.95.0'
+    VERSION = '0.96.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end


### PR DESCRIPTION
Ships the atomic JUnit XML write from #411 to RubyGems.

The fix prevents truncated `junit.xml` files (which caused `REXML::ParseException: Missing end tag` spam in downstream consumers — tracked in shop/issues#1546) by writing to a tempfile in the same directory and `File.rename`-ing on success.