### PR TITLE
Bump Gemfile.lock to ci-queue v0.96.0

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.95.0)
+    ci-queue (0.96.0)
       logger
 
 GEM


### PR DESCRIPTION
Follow-up to #412. The version bump there updated `version.rb` but missed `Gemfile.lock`, which still pinned `ci-queue (0.95.0)`. Shipit's RubyGems deploy runs `bundle install` in frozen mode and refused with:

> The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set

Updating the lockfile so the next deploy can proceed.