### PR TITLE
Accept unix:// URLs for the Redis backend

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.96.0)
+    ci-queue (0.97.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue.rb
+++ b/ruby/lib/ci/queue.rb
@@ -81,7 +81,13 @@ module CI
         Static
       when 'file', nil
         File
-      when 'redis', 'rediss'
+      when 'redis', 'rediss', 'unix'
+        # `unix://` URLs are forwarded to the Redis backend as-is;
+        # redis-client's URL parser accepts the unix:// scheme natively
+        # and treats the path as the socket path. This lets workloads
+        # that already run an in-process Redis on a unix socket (Nix
+        # build sandboxes, hermetic test harnesses, etc.) point ci-queue
+        # at it without exposing a TCP port.
         require 'ci/queue/redis'
         Redis
       else

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.96.0'
+    VERSION = '0.97.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end

--- a/ruby/test/ci/queue/redis_test.rb
+++ b/ruby/test/ci/queue/redis_test.rb
@@ -624,6 +624,11 @@ class CI::Queue::RedisTest < Minitest::Test
     assert_instance_of CI::Queue::Redis::Worker, queue
   end
 
+  def test_initialise_from_unix_uri
+    queue = CI::Queue.from_uri('unix:///tmp/redis.sock', config)
+    assert_instance_of CI::Queue::Redis::Worker, queue
+  end
+
   def test_first_reserve_at_is_set_on_first_reserve
     queue = worker(1)
     assert_nil queue.first_reserve_at


### PR DESCRIPTION
Forward unix-scheme URLs to the existing Redis backend instead of rejecting them in CI::Queue.from_uri. redis-client (redis 5.x's transport) already parses unix:// URLs natively and uses the path component as the socket path, so no changes are needed in the Redis backend itself; only the dispatch in CI::Queue needs to recognize the scheme.

This unblocks workloads that run an in-process Redis listening only on a unix socket — typically hermetic test sandboxes that want to avoid allocating TCP ports — from using ci-queue without an external patch or monkey-patch.