### PR TITLE
Drop EOL Pythons (3.7–3.9) from CI, add 3.12–3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11' ]
+        python: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     services:
       redis:
@@ -67,7 +67,12 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get -qq update
-          sudo apt-get install -y python${{ matrix.python }} python${{ matrix.python }}-distutils
+          sudo apt-get install -y python${{ matrix.python }}
+          # distutils was removed from the stdlib in Python 3.12, so the
+          # python3.X-distutils package only exists for older versions.
+          if dpkg --compare-versions "${{ matrix.python }}" lt "3.12"; then
+            sudo apt-get install -y python${{ matrix.python }}-distutils
+          fi
           sudo pip install autopep8 || true
       - name: Run Python tests
         run: |

--- a/python/Makefile
+++ b/python/Makefile
@@ -4,7 +4,7 @@ python_files := find . -path '*/.*' -prune -o -name '*.py' -print0
 python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
 python_version_major := $(word 1,${python_version_full})
 
-TOX_ENV ?= py37,py38,py39,py310,py311
+TOX_ENV ?= py310,py311,py312,py313,py314
 
 all: test
 

--- a/python/ciqueue/_pytest/test_queue.py
+++ b/python/ciqueue/_pytest/test_queue.py
@@ -1,4 +1,3 @@
-from distutils import util  # pylint: disable=no-name-in-module, import-modules-only
 from future.moves.urllib import parse as urlparse
 import ciqueue
 import ciqueue.distributed
@@ -12,6 +11,16 @@ class InvalidRedisUrl(Exception):
 
 def key_item(item):
     return item.nodeid
+
+
+def strtobool(value):
+    # Replacement for distutils.util.strtobool, removed in Python 3.12.
+    value = value.lower()
+    if value in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    if value in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    raise ValueError("invalid truth value {!r}".format(value))
 
 
 def parse_worker_args(query_string, tests_index):
@@ -51,7 +60,7 @@ def parse_redis_args(spec):
     if 'socket_connect_timeout' in query:
         result['socket_connect_timeout'] = int(query['socket_connect_timeout'][0])
     if 'retry_on_timeout' in query:
-        result['retry_on_timeout'] = bool(util.strtobool(query['retry_on_timeout'][0] or 'false'))
+        result['retry_on_timeout'] = strtobool(query['retry_on_timeout'][0] or 'false')
     if spec.scheme == "rediss":
         result['ssl'] = True
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py310,py311,py312,py313,py314
 
 [testenv]
 commands = pytest {posargs:-vv}

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,6 +35,7 @@ setuplib.setup(
     name='ciqueue',
     version='0.1',
     packages=['ciqueue', 'ciqueue._pytest'],
+    python_requires='>=3.10',
     install_requires=[
         'dill>=0.2.7',
         'pytest>=2.7',


### PR DESCRIPTION
## Why

Every PR's `python-tests (3.8)` job is currently failing with:

```
py38: skipped because could not find python interpreter with spec(s): py38
```

The interpreter is installed fine — the break is environmental: [virtualenv 21.5.0 (2026-06-13)](https://virtualenv.pypa.io/en/latest/changelog.html) dropped support for creating Python 3.8 environments, and `python/setup.py` doesn't pin virtualenv, so tox 4.6.4 can no longer materialize a `py38` env. The last green run on main (May 21, virtualenv 21.3.3) predates that release.

Rather than pinning an old virtualenv to keep an EOL interpreter alive, this updates the matrix to versions users actually run.

## What

- **Drop 3.8** (EOL 2024-10, actively broken in CI) and **3.9** (EOL 2025-10, next in line to be dropped by the toolchain — e.g. hatchling ≥1.28 already has) from the CI matrix
- Remove vestigial `py37`/`py38`/`py39` from the tox envlist (`setup.cfg`) and the `Makefile` `TOX_ENV` default (py37 was never even in the CI matrix)
- **Add 3.12, 3.13, 3.14** to the CI matrix and envlist
- Only install `python3.X-distutils` for < 3.12 (distutils was removed from the stdlib in 3.12, the apt package doesn't exist for newer versions)
- Replace `distutils.util.strtobool` in `ciqueue/_pytest/test_queue.py` with an inline helper with identical semantics (the `distutils` import broke test collection on 3.12+)
- Declare `python_requires='>=3.10'` in `setup.py`

3.10 is kept for now despite its Oct 2026 EOL being close; dropping it can be a follow-up.

## ⚠️ Branch protection

If `python-tests (3.8)` / `python-tests (3.9)` are configured as **required status checks**, an admin needs to swap them for the new matrix entries when this merges, otherwise PRs will wait forever on 'expected' checks.

## Testing

- ✅ CI green on the full new matrix: `python-tests (3.10)` through `(3.14)` on both push and pull_request runs
- Unblocks #417 and any other open PR once merged