### PR TITLE
Bump ci-queue to v0.98.0

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.97.0)
+    ci-queue (0.98.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.97.0'
+    VERSION = '0.98.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end


### PR DESCRIPTION
Bumps ci-queue to v0.98.0 for release, following the [release process](https://github.com/Shopify/ci-queue/blob/main/ruby/README.md#releasing-a-new-version).

Ships #420: per-worker-process execution metadata (`parallel_worker_id`, `parallel_worker_test_index`, `parallel_worker_pid`) on test results, carried into `log/test_data.json`.

Merging to `main` will trigger the ShipIt → RubyGems publish.

---
*AI generated (pi/claude, reviewed by @aiden before posting)*
