### PR TITLE
Record elapsed time for synthetic test results

### DIFF
--- a/ruby/lib/minitest/queue.rb
+++ b/ruby/lib/minitest/queue.rb
@@ -520,6 +520,7 @@ module Minitest
         if result
           result.start_timestamp = start_timestamp
           result.finish_timestamp = current_timestamp
+          result.time ||= (result.finish_timestamp - result.start_timestamp).to_f
         end
       end
 

--- a/ruby/lib/minitest/queue/test_data.rb
+++ b/ruby/lib/minitest/queue/test_data.rb
@@ -49,7 +49,7 @@ module Minitest
       end
 
       def test_duration
-        @test.time
+        @test.time || 0.0
       end
 
       def test_start_timestamp

--- a/ruby/test/minitest/queue/lazy_single_example_test.rb
+++ b/ruby/test/minitest/queue/lazy_single_example_test.rb
@@ -39,6 +39,7 @@ module Minitest::Queue
 
       assert result.error?
       assert_instance_of Minitest::UnexpectedError, result.failure
+      refute_nil result.time
       assert_nil example.source_location
     end
 
@@ -46,11 +47,16 @@ module Minitest::Queue
       loader = CI::Queue::FileLoader.new
       resolver = CI::Queue::ClassResolver
       example = LazySingleExample.new('MissingClass', 'test_missing', '/tmp/missing.rb', loader: loader, resolver: resolver)
+      times = [Time.at(100), Time.at(108)]
 
-      example.stub(:runnable, -> { raise LoadError, 'boom' }) do
-        result = example.run
-        assert result.error?
-        assert_instance_of Minitest::UnexpectedError, result.failure
+      CI::Queue.stub(:time_now, -> { times.shift }) do
+        example.stub(:runnable, -> { raise LoadError, 'boom' }) do
+          result = example.run
+          assert result.error?
+          assert_instance_of Minitest::UnexpectedError, result.failure
+          assert_equal 8.0, result.time
+          assert_instance_of Float, result.time
+        end
       end
     end
 
@@ -70,13 +76,17 @@ module Minitest::Queue
         loader = CI::Queue::FileLoader.new
         resolver = CI::Queue::ClassResolver
         example = LazySingleExample.new(class_name, 'test_no_longer_exists', file_path, loader: loader, resolver: resolver)
+        times = [Time.at(100), Time.at(108)]
 
         old_queue = Minitest.queue
         Minitest.queue = Struct.new(:config).new(CI::Queue::Configuration.new(skip_stale_tests: true))
 
-        result = example.run
+        result = CI::Queue.stub(:time_now, -> { times.shift }) { example.run }
 
         assert result.skipped?
+        refute_nil result.time
+        assert_equal 8.0, result.time
+        assert_instance_of Float, result.time
         assert_match(/Stale preresolved entry/, result.failure.message)
         assert_match(/test_no_longer_exists/, result.failure.message)
       ensure

--- a/ruby/test/minitest/queue/test_data_test.rb
+++ b/ruby/test/minitest/queue/test_data_test.rb
@@ -42,6 +42,34 @@ module Minitest::Queue
       assert_equal 42, data[:error_file_number]
     end
 
+    def test_duration_defaults_to_zero_when_the_result_has_no_time
+      test = result('test_foo')
+      test.time = nil
+
+      data = TestData.new(
+        test: test,
+        index: 0,
+        namespace: 'namespace',
+        base_path: Minitest::Queue.project_root,
+      ).to_h
+
+      assert_equal 0.0, data[:test_duration]
+      assert_instance_of Float, data[:test_duration]
+    end
+
+    def test_duration_is_preserved_when_the_result_ran
+      test = result('test_foo')
+
+      data = TestData.new(
+        test: test,
+        index: 0,
+        namespace: 'namespace',
+        base_path: Minitest::Queue.project_root,
+      ).to_h
+
+      assert_equal 0.12, data[:test_duration]
+    end
+
     def test_parallel_worker_metadata_defaults_to_nil
       test = result('test_foo')
 


### PR DESCRIPTION
## Summary

- set missing `LazySingleExample` durations from its elapsed start and finish timestamps, including class resolution and file loading time
- preserve durations measured by Minitest and emit synthetic durations as floating-point values
- retain a `0.0` exporter fallback so any remaining timeless result cannot invalidate the batch

`LazySingleExample` synthesizes results for load errors and stale queue entries. Those results bypass Minitest's timing path, leaving `time` nil; Monorail requires `test_duration` to be a non-nullable double, so one such result can reject the exported batch.

## Test plan

- `shadowenv exec -- bundle exec rake test TEST_FILES='test/minitest/queue/lazy_single_example_test.rb test/minitest/queue/test_data_test.rb'`
- 15 tests, 48 assertions, 0 failures
- verified eight-second load-error and stale-skip durations, preservation of a normal `0.12` duration, and the `0.0` exporter fallback