### PR TITLE
Make CI::Queue::Bisect#config public

### DIFF
--- a/ruby/lib/ci/queue/bisect.rb
+++ b/ruby/lib/ci/queue/bisect.rb
@@ -47,8 +47,6 @@ module CI
         @tests = second_half
       end
 
-      # Public like every other queue's config (CI::Queue::Common), since consumers
-      # configure the queue while tests load.
       attr_reader :config
 
       private

--- a/ruby/lib/ci/queue/bisect.rb
+++ b/ruby/lib/ci/queue/bisect.rb
@@ -47,9 +47,11 @@ module CI
         @tests = second_half
       end
 
-      private
-
+      # Public like every other queue's config (CI::Queue::Common), since consumers
+      # configure the queue while tests load.
       attr_reader :config
+
+      private
 
       def slices
         @tests.each_slice((@tests.size / 2.0).ceil).to_a

--- a/ruby/test/ci/queue/bisect_test.rb
+++ b/ruby/test/ci/queue/bisect_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class CI::Queue::BisectTest < Minitest::Test
+  TEST_LIST_PATH = '/tmp/bisect-queue-test.txt'.freeze
+
+  def test_config_is_public
+    config = CI::Queue::Configuration.new(failing_test: 'ATest#test_bar')
+    File.write(TEST_LIST_PATH, "ATest#test_foo\nATest#test_bar\n")
+
+    assert_same(config, CI::Queue::Bisect.new(TEST_LIST_PATH, config).config)
+  end
+end

--- a/ruby/test/ci/queue/bisect_test.rb
+++ b/ruby/test/ci/queue/bisect_test.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 require 'test_helper'
+require 'tempfile'
 
 class CI::Queue::BisectTest < Minitest::Test
-  TEST_LIST_PATH = '/tmp/bisect-queue-test.txt'.freeze
-
   def test_config_is_public
-    config = CI::Queue::Configuration.new(failing_test: 'ATest#test_bar')
-    File.write(TEST_LIST_PATH, "ATest#test_foo\nATest#test_bar\n")
+    config = CI::Queue::Configuration.new
+    config.failing_test = 'ATest#test_bar'
 
-    assert_same(config, CI::Queue::Bisect.new(TEST_LIST_PATH, config).config)
+    Tempfile.create('test_order') do |file|
+      file.write("ATest#test_foo\nATest#test_bar\n")
+      file.flush
+
+      assert_same(config, CI::Queue::Bisect.new(file.path, config).config)
+    end
   end
 end


### PR DESCRIPTION
Every other queue exposes `config` publicly through `CI::Queue::Common`. Consumers configure the queue while tests load (e.g. setting `config.test_id_normalizer` from a Rails initializer), and since `bisect_command` assigns `Minitest.queue` before loading tests, the private reader raises `NoMethodError` and aborts the bisect.