### PR TITLE
Bump ci-queue to v0.99.0

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ci-queue (0.98.0)
+    ci-queue (0.99.0)
       logger
 
 GEM

--- a/ruby/lib/ci/queue/version.rb
+++ b/ruby/lib/ci/queue/version.rb
@@ -2,7 +2,7 @@
 
 module CI
   module Queue
-    VERSION = '0.98.0'
+    VERSION = '0.99.0'
     DEV_SCRIPTS_ROOT = ::File.expand_path('../../../../../redis', __FILE__)
     RELEASE_SCRIPTS_ROOT = ::File.expand_path('../redis', __FILE__)
   end


### PR DESCRIPTION
Bumps the Ruby gem version to 0.99.0.

Changes since v0.98.0:
- #423 — Record elapsed time for synthetic test results
- #424 — Make `CI::Queue::Bisect#config` public